### PR TITLE
added clientid to data to fix listening issue

### DIFF
--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -488,24 +488,39 @@ class Client(object):
 
 
     def on_message(self, mid, author_id, author_name, message, metadata):
+        '''
+        subclass Client and override this method to add custom behavior on event
+        '''
         self.markAsDelivered(author_id, mid)
         self.markAsRead(author_id)
         print("%s said: %s"%(author_name, message))
 
 
     def on_typing(self, author_id):
+        '''
+        subclass Client and override this method to add custom behavior on event
+        '''
         pass
 
 
     def on_read(self, author, reader, time):
+        '''
+        subclass Client and override this method to add custom behavior on event
+        '''
         pass
 
 
     def on_inbox(self, viewer, unseen, unread, other_unseen, other_unread, timestamp):
+        '''
+        subclass Client and override this method to add custom behavior on event
+        '''
         pass
 
 
     def on_message_error(self, exception, message):
+        '''
+        subclass Client and override this method to add custom behavior on event
+        '''
         print("Exception: ")
         print(exception)
 

--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -411,7 +411,8 @@ class Client(object):
         data = {
             "msgs_recv": 0,
             "sticky_token": sticky,
-            "sticky_pool": pool
+            "sticky_pool": pool,
+            "clientid": self.client_id,
         }
 
         r = self._get(StickyURL, data)


### PR DESCRIPTION
Solution for #51 where `content` received in `parseMessage` is always {u'reason': 110, u't': u'refresh', u'seq': 0} which makes `on_message` never fire.

Also added some docstrings that instruct users to subclass Client and override the event handlers to have custom behaviour. 