### PR TITLE
fixed a bug that prevented fbchat from returning the list of all users

### DIFF
--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -356,8 +356,12 @@ class Client(object):
         payload = j['payload']
         users = []
 
-        for k in payload.keys(): 
-            user = self._adapt_user_in_chat_to_user_model(payload[k])
+        for k in payload.keys():
+            try:
+                user = self._adapt_user_in_chat_to_user_model(payload[k])
+            except KeyError:
+                continue
+
             users.append(User(user))
 
         return users


### PR DESCRIPTION
I think that this bug occurs because some users have bugged contact lists, so I added this try block to ignore such contacts.