### PR TITLE
Fix for getUserInfo method throwing an error

### DIFF
--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -902,7 +902,7 @@ class Client(object):
             if type(_fbid) == int:
                 return _fbid
 
-            if type(_fbid) == str and 'fbid:' in _fbid:
+            if type(_fbid) in [str, unicode] and 'fbid:' in _fbid:
                 return int(_fbid[5:])
 
         user_ids = [fbidStrip(uid) for uid in user_ids]


### PR DESCRIPTION
The participants property on thread object is returning a list of unicodes. If you then pass these unicodes to getUserInfo, they are not being picked up in the if statement on line 905 in the fbidStrip method, so the fbidStrip method was returning a tuple of None objects. The conditional now matches and reformats both str and unicode objects.