### PR TITLE
Fixes #126

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Getting last messages sent
 
 .. code-block:: python
     
-    last_messages = client.getThreadInfo(friend.uid,0)
+    last_messages = client.getThreadInfo(friend.uid, last_n=20)
     last_messages.reverse()  # messages come in reversed order
     
     for message in last_messages:

--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -616,7 +616,7 @@ class Client(object):
         # `start` doesn't matter, always returns from the last
         # data['messages[{}][{}][offset]'.format(key, userID)] = start
         data = {'messages[{}][{}][offset]'.format(key, userID): 0,
-                'messages[{}][{}][limit]'.format(key, userID): last_n,
+                'messages[{}][{}][limit]'.format(key, userID): last_n - 1,
                 'messages[{}][{}][timestamp]'.format(key, userID): now()}
 
         r = self._post(MessagesURL, query=data)


### PR DESCRIPTION
Fixes #126 
Updated readme, and changed `getThreadInfo`, so `last_n` actually specifies the amount of retrieved messages