### PR TITLE
reintroduce things skipped on conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *py[co]
 
+.idea/
+
 # Test scripts
 *.sh
 

--- a/fbchat/event_hook.py
+++ b/fbchat/event_hook.py
@@ -1,0 +1,57 @@
+import inspect
+
+
+class EventHook(object):
+    """
+    A simple implementation of the Observer-Pattern.
+    The user can specify an event signature upon inizializazion,
+    defined by kwargs in the form of argumentname=class (e.g. id=int).
+    The arguments' types are not checked in this implementation though.
+    Callables with a fitting signature can be added with += or removed with -=.
+    All listeners can be notified by calling the EventHook class with fitting
+    arguments.
+    
+    Thanks http://stackoverflow.com/a/35957226/5556222
+    """
+
+    def __init__(self, **signature):
+        self._signature = signature
+        self._argnames = set(signature.keys())
+        self._handlers = []
+
+    def _kwargs_str(self):
+        return ", ".join(k+"="+v.__name__ for k, v in self._signature.items())
+
+    def __iadd__(self, handler):
+        params = inspect.signature(handler).parameters
+        valid = True
+        argnames = set(n for n in params.keys())
+        if argnames != self._argnames:
+            valid = False
+        for p in params.values():
+            if p.kind == p.VAR_KEYWORD:
+                valid = True
+                break
+            if p.kind not in (p.POSITIONAL_OR_KEYWORD, p.KEYWORD_ONLY):
+                valid = False
+                break
+        if not valid:
+            raise ValueError("Listener must have these arguments: (%s)"
+                             % self._kwargs_str())
+        self._handlers.append(handler)
+        return self
+
+    def __isub__(self, handler):
+        self._handlers.remove(handler)
+        return self
+
+    def __call__(self, *args, **kwargs):
+        if args or set(kwargs.keys()) != self._argnames:
+            raise ValueError("This EventHook must be called with these " +
+                             "keyword arguments: (%s)" % self._kwargs_str() +
+                             ", but was called with: (%s)" %self._signature)
+        for handler in self._handlers[:]:
+            handler(**kwargs)
+
+    def __repr__(self):
+        return "EventHook(%s)" % self._kwargs_str()

--- a/fbchat/models.py
+++ b/fbchat/models.py
@@ -2,15 +2,7 @@ from __future__ import unicode_literals
 import sys
 from enum import Enum
 
-class Base():
-    def __repr__(self):
-        uni = self.__unicode__()
-        return uni.encode('utf-8') if sys.version_info < (3, 0) else uni
-
-    def __unicode__(self):
-        return u'<%s %s (%s)>' % (self.type.upper(), self.name, self.url)
-
-class User(Base):
+class User:
     def __init__(self, data):
         if data['type'] != 'user':
             raise Exception("[!] %s <%s> is not a user" % (data['text'], data['path']))
@@ -22,11 +14,53 @@ class User(Base):
         self.score = data['score']
         self.data = data
 
-class Thread():
+    def __repr__(self):
+        uni = self.__unicode__()
+        return uni.encode('utf-8') if sys.version_info < (3, 0) else uni
+
+    def __unicode__(self):
+        return u'<%s %s (%s)>' % (self.type.upper(), self.name, self.url)
+
+    @staticmethod
+    def adaptFromChat(user_in_chat):
+        """ Adapts user info from chat to User model acceptable initial dict
+
+        :param user_in_chat: user info from chat
+
+        'dir': None,
+        'mThumbSrcSmall': None,
+        'is_friend': False,
+        'is_nonfriend_messenger_contact': True,
+        'alternateName': '',
+        'i18nGender': 16777216,
+        'vanity': '',
+        'type': 'friend',
+        'searchTokens': ['Voznesenskij', 'Sergej'],
+        'thumbSrc': 'https://fb-s-b-a.akamaihd.net/h-ak-xfa1/v/t1.0-1/c9.0.32.32/p32x32/10354686_10150004552801856_220367501106153455_n.jpg?oh=71a87d76d4e4d17615a20c43fb8dbb47&oe=59118CE4&__gda__=1493753268_ae75cef40e9785398e744259ccffd7ff',
+        'mThumbSrcLarge': None,
+        'firstName': 'Sergej',
+        'name': 'Sergej Voznesenskij',
+        'uri': 'https://www.facebook.com/profile.php?id=100014812758264',
+        'id': '100014812758264',
+        'gender': 2
+        """
+
+        return {
+            'type': 'user',
+            'uid': user_in_chat['id'],
+            'photo': user_in_chat['thumbSrc'],
+            'path': user_in_chat['uri'],
+            'text': user_in_chat['name'],
+            'score': '',
+            'data': user_in_chat,
+        }
+
+
+class Thread:
     def __init__(self, **entries): 
         self.__dict__.update(entries)
 
-class Message():
+class Message:
     def __init__(self, **entries):
         self.__dict__.update(entries)
 
@@ -40,22 +74,15 @@ class TypingStatus(Enum):
 
 
 # WIP
-class StickerSize(Enum):
+class EmojiSize(Enum):
     LARGE = '369239383222810'
     MEDIUM = '369239343222814'
     SMALL = '369239263222822'
 
-#class Size(Enum):
-#    LARGE = 'large'
-#    MEDIUM = 'medium'
-#    SMALL = 'small'
-
-Size = StickerSize
-
 LIKES = {
-    'l': Size.LARGE,
-    'm': Size.MEDIUM,
-    's': Size.SMALL
+    'l': EmojiSize.LARGE,
+    'm': EmojiSize.MEDIUM,
+    's': EmojiSize.SMALL
 }
 LIKES['large'] = LIKES['l']
 LIKES['medium'] =LIKES['m']

--- a/fbchat/utils.py
+++ b/fbchat/utils.py
@@ -26,6 +26,7 @@ GENDERS = {
     11: 'unknown_plural',
 }
 
+
 def now():
     return int(time()*1000)
 
@@ -40,7 +41,7 @@ def digit_to_char(digit):
         return str(digit)
     return chr(ord('a') + digit - 10)
 
-def str_base(number,base):
+def str_base(number, base):
     if number < 0:
         return '-' + str_base(-number, base)
     (d, m) = divmod(number, base)
@@ -51,17 +52,17 @@ def str_base(number,base):
 def generateMessageID(client_id=None):
     k = now()
     l = int(random() * 4294967295)
-    return ("<%s:%s-%s@mail.projektitan.com>" % (k, l, client_id));
+    return "<%s:%s-%s@mail.projektitan.com>" % (k, l, client_id)
 
 def getSignatureID():
     return hex(int(random() * 2147483648))
 
-def generateOfflineThreadingID() :
+def generateOfflineThreadingID():
     ret = now()
-    value = int(random() * 4294967295);
+    value = int(random() * 4294967295)
     string = ("0000000000000000000000" + bin(value))[-22:]
     msgs = bin(ret) + string
-    return str(int(msgs,2))
+    return str(int(msgs, 2))
 
 def isUserToThreadType(is_user):
     return ThreadType.USER if is_user else ThreadType.GROUP

--- a/test_data.json
+++ b/test_data.json
@@ -1,0 +1,6 @@
+{
+  "email": "",
+  "password": "",
+  "user_thread_id": "",
+  "group_thread_id": ""
+}

--- a/tests.py
+++ b/tests.py
@@ -18,14 +18,7 @@ logging.basicConfig(level=logging.INFO)
 Tests for fbchat
 ~~~~~~~~~~~~~~~~
 
-To use these tests, make a json file called test_data.json, put this example in it, and fill in the gaps:
-{
-    "email": "example@email.com",
-    "password": "example_password",
-    "group_thread_id": 0,
-    "user_thread_id": 0
-}
-or type this information manually in the terminal prompts.
+To use these tests, fill in test_data.json or type this information manually in the terminal prompts.
 
 - email: Your (or a test user's) email / phone number
 - password: Your (or a test user's) password
@@ -169,7 +162,7 @@ if __name__ == 'tests':
         pass
 
     try:
-        with open(path.join(path.dirname(__file__), 'test_data.js'), 'r') as f:
+        with open(path.join(path.dirname(__file__), 'test_data.json'), 'r') as f:
             json = json.load(f)
         email = json['email']
         password = json['password']


### PR DESCRIPTION
Size should be EmojiSize so not to cause confusion

IMO we should ditch all deprecation warnings, make it backwards-incompatible and bump to version 1.0 once I add more chat methods. there is no correct way to keep on_* methods with a warning, they would be called everytime and generate the warning everytime for everyone. this is like dragging a dead horse around.