### PR TITLE
Swapped out for a better error output.

### DIFF
--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -897,7 +897,6 @@ class Client(object):
             if type(_fbid) == int:
                 return _fbid
 
-            print(type(_fbid))
             if type(_fbid) in [str, bytes] and 'fbid:' in _fbid:
                 return int(_fbid[5:])
 

--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -24,6 +24,7 @@ from .models import *
 from .stickers import *
 import time
 import sys
+import traceback
 
 # Python 3 does not have raw_input, whereas Python 2 has and it's more secure
 try:
@@ -653,7 +654,8 @@ class Client(object):
             for participant in j['payload']['participants']:
                 participants[participant["fbid"]] = participant["name"]
         except Exception as e:
-            log.warning(str(j))
+            traceback.print_exc()
+#           log.warning(str(j))
 
         # Prevent duplicates in self.threads
         threadIDs = [getattr(x, "thread_id") for x in self.threads]
@@ -1026,7 +1028,8 @@ class Client(object):
 
     def on_message_error(self, exception, message):
         """subclass Client and override this method to add custom behavior on event"""
-        log.warning("Exception:\n{}".format(exception))
+        traceback.print_exc()
+#        log.warning("Exception:\n{}".format(exception))
 
 
     def on_qprimer(self, timestamp):

--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -897,7 +897,8 @@ class Client(object):
             if type(_fbid) == int:
                 return _fbid
 
-            if type(_fbid) in [str, unicode] and 'fbid:' in _fbid:
+            print(type(_fbid))
+            if type(_fbid) in [str, bytes] and 'fbid:' in _fbid:
                 return int(_fbid[5:])
 
         user_ids = [fbidStrip(uid) for uid in user_ids]


### PR DESCRIPTION
It sidesteps the log() feature, but at least now you get which file and at what line the error occurred.

Previous error could look something like this: `name 'unicode' is not defined`
Now you'll get: 

    File "/usr/lib/python3.6/site-packages/fbchat-0.10.1-py3.6.egg/fbchat/client.py", line 900, in fbidStrip
      if type(_fbid) in [str, unicode] and 'fbid:' in _fbid:
    NameError: name 'unicode' is not defined