### PR TITLE
Add extensible_attachment field to Message for fb share objects

### DIFF
--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -736,9 +736,10 @@ class Client(object):
             if k['thread_type'] == 1:
                 if k['other_user_fbid'] not in participants:
                     raise Exception('A thread was not in participants: {}'.format(j['payload']))
+                participants[k['other_user_fbid']].last_message_timestamp = k['last_message_timestamp']
                 entries.append(participants[k['other_user_fbid']])
             elif k['thread_type'] == 2:
-                entries.append(Group(k['thread_fbid'], participants=set([p.strip('fbid:') for p in k['participants']]), photo=k['image_src'], name=k['name']))
+                entries.append(Group(k['thread_fbid'], participants=set([p.strip('fbid:') for p in k['participants']]), photo=k['image_src'], name=k['name'], last_message_timestamp=k['last_message_timestamp']))
             else:
                 raise Exception('A thread had an unknown thread type: {}'.format(k))
 

--- a/fbchat/graphql.py
+++ b/fbchat/graphql.py
@@ -75,7 +75,8 @@ def graphql_to_message(message):
         text=message.get('message').get('text'),
         mentions=[Mention(m.get('entity', {}).get('id'), offset=m.get('offset'), length=m.get('length')) for m in message.get('message').get('ranges', [])],
         sticker=message.get('sticker'),
-        attachments=message.get('blob_attachments')
+        attachments=message.get('blob_attachments'),
+        extensible_attachment=message.get('extensible_attachment')
     )
 
 def graphql_to_user(user):

--- a/fbchat/models.py
+++ b/fbchat/models.py
@@ -125,8 +125,10 @@ class Message(object):
     sticker = str
     #: A list of attachments
     attachments = list
+    #: An extensible attachment, e.g. share object
+    extensible_attachment = dict
 
-    def __init__(self, uid, author=None, timestamp=None, is_read=None, reactions=[], text=None, mentions=[], sticker=None, attachments=[]):
+    def __init__(self, uid, author=None, timestamp=None, is_read=None, reactions=[], text=None, mentions=[], sticker=None, attachments=[], extensible_attachment={}):
         """Represents a Facebook message"""
         self.uid = uid
         self.author = author
@@ -137,6 +139,7 @@ class Message(object):
         self.mentions = mentions
         self.sticker = sticker
         self.attachments = attachments
+        self.extensible_attachment = extensible_attachment
 
 
 class Mention(object):

--- a/fbchat/models.py
+++ b/fbchat/models.py
@@ -13,13 +13,16 @@ class Thread(object):
     photo = str
     #: The name of the thread
     name = str
+    #: Timestamp of last message
+    last_message_timestamp = str
 
-    def __init__(self, _type, uid, photo=None, name=None):
+    def __init__(self, _type, uid, photo=None, name=None, last_message_timestamp=None):
         """Represents a Facebook thread"""
         self.uid = str(uid)
         self.type = _type
         self.photo = photo
         self.name = name
+        self.last_message_timestamp = last_message_timestamp
 
     def __repr__(self):
         return self.__unicode__()


### PR DESCRIPTION
Add a new field for fb share objects (like videos, links, pictures shared from Facebook to a messenger thread). Modeled it off the attachments field, which just takes the dict from the graphql response.

E.g. turns this:
<img width="361" alt="screen shot 2017-06-28 at 1 11 14 pm" src="https://user-images.githubusercontent.com/732493/27658455-f550cd70-5c04-11e7-8a37-138212832a9d.png">

into this:
```
'extensible_attachment':{  
    u'story_attachment':{  
        u'description':{  
            u'text':u'HyperTrack\u2019s Founder & CEO,
            Kashyap Deorah,
            had me hooked based solely on his previous exploits,
            but his fledgling start up,
            HyperTrack\u2026'
        },
        u'url':u'https://l.facebook.com/l.php?u=https%3A%2F%2Fmedium.com%2F%40kevinhartz%2Ffounders-fund-is-excited-to-announce-an-investment-from-our-ff-angel-fund-in-hypertrack-7e309d711c5f&h=ATOp95t7VdT5iME8E1rymEVax-d_Q0Yu7z2OXYs9aZ6gplMGYg7_5BHUswNtTnJK3CPE5zbXA0JyZYmfR8fLlOzHJgOYoL9xGitGD9PtbreZhbfH2OACBM_b9Y8L5Il_3hoBoIrbbds0UL0&s=1&enc=AZPTlLokt8ZOrB19h1OvowcYxABR-ifNm3j1QranP8azYdyMm-Are_u2lqnSd6vG_mGk2E8R9Q6tTYf1VDAfuCy6',
        u'media':{  
            u'playable_url':None,
            u'image':{  
                u'width':960,
                u'uri':u'https://external-sjc2-1.xx.fbcdn.net/safe_image.php?d=AQDDiSWtQyA_cOV3&w=960&h=960&url=https%3A%2F%2Fcdn-images-1.medium.com%2Fmax%2F1200%2F1%2AEnfc2XPfZFOK7NHRST0AYw.jpeg&cfs=1&_nc_hash=AQCrhD0zP1y32rPi',
                u'height':960
            },
            u'animated_image':None,
            u'is_playable':False,
            u'playable_duration_in_ms':0
        },
        u'deduplication_key':u'155527424369401354d46a29b18f9201',
        u'title_with_entities':{  
            u'text':u'Founders Fund is excited to announce an investment from our FF Angel Fund in HyperTrack.'
        },
        u'source':{  
            u'text':u'medium.com'
        },
        u'subattachments':[  

        ],
        u'style_list':[  
            u'share',
            u'fallback'
        ],
        u'target':{  
            u'__typename':u'ExternalUrl'
        },
        u'action_links':[  

        ],
        u'properties':[  

        ],
        u'messaging_attribution':None
    },
    u'legacy_attachment_id':u'10208973666528918'
}
```