### PR TITLE
Add on chat presence event

### DIFF
--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -1355,7 +1355,7 @@ class Client(object):
                         thread_id, thread_type = getThreadIdAndThreadType(metadata)
                         self.onMessage(mid=mid, author_id=author_id, message=message,
                                        thread_id=thread_id, thread_type=thread_type, ts=ts, metadata=metadata, msg=m)
-
+                        
                     # Unknown message type
                     else:
                         self.onUnknownMesssageType(msg=m)
@@ -1388,7 +1388,16 @@ class Client(object):
                 # Is sent before any other message
                 elif mtype == "deltaflow":
                     pass
-
+                
+                # Chat timestamp
+                elif mtype == "chatproxy-presence":
+                    buddyList = []
+                    for id in m.get("buddyList", {}).keys():
+                        payload = m["buddyList"][id]
+                        timestamp = payload["lat"]
+                        buddyList.append({id:timestamp})
+                    self.onChatTimestamp(buddylist=buddyList, msg=m)
+                    
                 # Unknown message type
                 else:
                     self.onUnknownMesssageType(msg=m)
@@ -1676,7 +1685,15 @@ class Client(object):
         """
         pass
 
+    def onChatTimestamp(self, buddylist={), msg={}):
+                                         """
+        Called when the client receives chat online presence update
 
+        :param buddylist: A list of dicts with friend id and last seen timestamp
+        :param msg: A full set of the data recieved
+        """
+        log.debug('Chat Timestamps received: {}'.format(buddylist))
+        
     def onUnknownMesssageType(self, msg={}):
         """
         Called when the client is listening, and some unknown data was recieved


### PR DESCRIPTION
Last_seen time stamps were handled in unknown message type, this info is freely available and potentially useful

Allows for some nasty stuff, like tracking your friend's online patterns and deduce their lives

Just popped online and offline again -> probably checked a message on phone
Usually online from 20:00 to 01:00 but not today ->  wasnt home
Usually offline from 01:00 to 10:00 -> sleep time

disclaimer: i was using this by over-riding the class in my code so i know it works, however i edited the code quickly on browser without testing to make this PR