### PR TITLE
No FileNotFoundError in py2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('README.rst') as f:
 
 try:
     requirements = [line.rstrip('\n') for line in open(os.path.join('fbchat.egg-info', 'requires.txt'))]
-except FileNotFoundError:
+except IOError:
     requirements = [line.rstrip('\n') for line in open('requirements.txt')]
 
 version = None


### PR DESCRIPTION
In setup.py
There is no FileNotFoundError in Python2
However, since we don't do anything with exception anyway, using IOError is clean and work for both py2 and py3.