### PR TITLE
Improve login speed and reliability

### DIFF
--- a/fbchat/graphql.py
+++ b/fbchat/graphql.py
@@ -31,7 +31,7 @@ def graphql_color_to_enum(color):
     try:
         return ThreadColor('#{}'.format(color[2:].lower()))
     except ValueError:
-        raise Exception('Could not get ThreadColor from color: {}'.format(color))
+        raise FBchatException('Could not get ThreadColor from color: {}'.format(color))
 
 def get_customization_info(thread):
     if thread is None or thread.get('customization_info') is None:
@@ -176,7 +176,7 @@ class GraphQL(object):
                 'query_params': params
             }
         else:
-            raise Exception('A query or doc_id must be specified')
+            raise FBchatValueError('A query or doc_id must be specified')
 
 
     FRAGMENT_USER = """

--- a/fbchat/utils.py
+++ b/fbchat/utils.py
@@ -9,6 +9,12 @@ import warnings
 import logging
 from .models import *
 
+# Python 2: urlparse, Python 3: urllib.parse
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
+
 # Python 2's `input` executes the input, whereas `raw_input` just returns the input
 try:
     input = raw_input

--- a/tests.py
+++ b/tests.py
@@ -9,7 +9,7 @@ from getpass import getpass
 from sys import argv
 from os import path, chdir
 from glob import glob
-from fbchat import Client
+from fbchat import Client, FBchatException, FBchatValueError
 from fbchat.models import *
 import py_compile
 
@@ -21,6 +21,7 @@ Testing script for `fbchat`.
 Full documentation on https://fbchat.readthedocs.io/
 
 """
+
 
 class CustomClient(Client):
     def __init__(self, *args, **kwargs):
@@ -48,7 +49,7 @@ class TestFbchat(unittest.TestCase):
 
         self.assertFalse(client.isLoggedIn())
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(FBchatException):
             client.login('<email>', '<password>', max_tries=1)
 
         client.login(email, password)
@@ -72,7 +73,7 @@ class TestFbchat(unittest.TestCase):
 
         # resetDefaultThread
         client.resetDefaultThread()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(FBchatValueError):
             client.sendMessage('should_not_send')
 
     def test_fetchAllUsers(self):
@@ -108,9 +109,9 @@ class TestFbchat(unittest.TestCase):
     def test_sendMessage(self):
         self.assertIsNotNone(client.sendMessage('test_send_user★', user_id, ThreadType.USER))
         self.assertIsNotNone(client.sendMessage('test_send_group★', group_id, ThreadType.GROUP))
-        with self.assertRaises(Exception):
+        with self.assertRaises(FBchatException):
             client.sendMessage('test_send_user_should_fail★', user_id, ThreadType.GROUP)
-        with self.assertRaises(Exception):
+        with self.assertRaises(FBchatException):
             client.sendMessage('test_send_group_should_fail★', group_id, ThreadType.USER)
 
     def test_sendImages(self):
@@ -188,7 +189,6 @@ class TestFbchat(unittest.TestCase):
         client.setTypingStatus(TypingStatus.STOPPED, thread_id=user_id, thread_type=ThreadType.USER)
         client.setTypingStatus(TypingStatus.TYPING, thread_id=group_id, thread_type=ThreadType.GROUP)
         client.setTypingStatus(TypingStatus.STOPPED, thread_id=group_id, thread_type=ThreadType.GROUP)
-
 
 def start_test(param_client, param_group_id, param_user_id, tests=[]):
     global client


### PR DESCRIPTION
This should increase login speed and reliability, by making one less request when logging in, and adding an extra check if request contains the parameter `next`

I've also added some custom exceptions, since it'll be useful to see where the exception is actually coming from.

This has not yet been tested with 2FA, and while it should work, I need someone to test this