### PR TITLE
Possibly fixes #175, added custom Exception classes

### DIFF
--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -1438,17 +1438,17 @@ class Client(object):
         """
         try:
             if markAlive: self._ping(self.sticky, self.pool)
-            try:
-                content = self._pullMessage(self.sticky, self.pool)
-                if content: self._parseMessage(content)
-            except requests.exceptions.RequestException:
-                pass
-            except Exception as e:
-                return self.onListenError(exception=e)
+            content = self._pullMessage(self.sticky, self.pool)
+            if content:
+                self._parseMessage(content)
         except KeyboardInterrupt:
             return False
-        except requests.exceptions.Timeout:
+        except requests.Timeout:
             pass
+        except requests.ConnectionError:
+            time.sleep(30)
+        except Exception as e:
+            return self.onListenError(exception=e)
 
         return True
 
@@ -1509,8 +1509,10 @@ class Client(object):
         Called when an error was encountered while listening
 
         :param exception: The exception that was encountered
+        :return: Whether the loop should keep running
         """
         log.exception('Got exception while listening')
+        return True
 
 
     def onMessage(self, mid=None, author_id=None, message=None, thread_id=None, thread_type=ThreadType.USER, ts=None, metadata=None, msg={}):

--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -157,7 +157,10 @@ class Client(object):
         self.payloadDefault = {}
         self.client_id = hex(int(random()*2147483648))[2:]
         self.start_time = now()
-        self.uid = str(self._session.cookies['c_user'])
+        self.uid = self._session.cookies.get_dict().get('c_user')
+        if self.uid is None:
+            raise Exception('Could not find c_user cookie')
+        self.uid = str(self.uid)
         self.user_channel = "p_" + self.uid
         self.ttstamp = ''
 

--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -92,7 +92,7 @@ class Client(object):
         self.req_counter += 1
         return payload
 
-    def _fix_1357004(self, error_code):
+    def _fix_fb_errors(self, error_code):
         """
         This fixes "Please try closing and re-opening your browser window" errors (1357004)
         This error usually happens after 1-2 days of inactivity
@@ -112,7 +112,7 @@ class Client(object):
         try:
             return check_request(r, as_json=as_json)
         except FBchatFacebookError as e:
-            if error_retries > 0 and self._fix_1357004(e.fb_error_code):
+            if error_retries > 0 and self._fix_fb_errors(e.fb_error_code):
                 return self._get(url, query=query, timeout=timeout, fix_request=fix_request, as_json=as_json, error_retries=error_retries-1)
             raise e
 
@@ -124,7 +124,7 @@ class Client(object):
         try:
             return check_request(r, as_json=as_json)
         except FBchatFacebookError as e:
-            if error_retries > 0 and self._fix_1357004(e.fb_error_code):
+            if error_retries > 0 and self._fix_fb_errors(e.fb_error_code):
                 return self._post(url, query=query, timeout=timeout, fix_request=fix_request, as_json=as_json, error_retries=error_retries-1)
             raise e
 
@@ -133,7 +133,7 @@ class Client(object):
         try:
             return graphql_response_to_json(content)
         except FBchatFacebookError as e:
-            if error_retries > 0 and self._fix_1357004(e.fb_error_code):
+            if error_retries > 0 and self._fix_fb_errors(e.fb_error_code):
                 return self._graphql(payload, error_retries=error_retries-1)
             raise e
 
@@ -154,7 +154,7 @@ class Client(object):
         try:
             return check_request(r, as_json=as_json)
         except FBchatFacebookError as e:
-            if error_retries > 0 and self._fix_1357004(e.fb_error_code):
+            if error_retries > 0 and self._fix_fb_errors(e.fb_error_code):
                 return self._postFile(url, files=files, query=query, timeout=timeout, fix_request=fix_request, as_json=as_json, error_retries=error_retries-1)
             raise e
 

--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -351,8 +351,8 @@ class Client(object):
             # Load cookies into current session
             self._session.cookies = requests.cookies.merge_cookies(self._session.cookies, session_cookies)
             self._postLogin()
-        except FBchatException as e:
-            self.exception('Failed loading session')
+        except Exception as e:
+            log.exception('Failed loading session')
             self._resetValues()
             return False
         return True

--- a/fbchat/graphql.py
+++ b/fbchat/graphql.py
@@ -143,7 +143,11 @@ def graphql_queries_to_json(*queries):
     return json.dumps(rtn)
 
 def graphql_response_to_json(content):
-    j = json.loads(content, cls=ConcatJSONDecoder)
+    content = strip_to_json(content) # Usually only needed in some error cases
+    try:
+        j = json.loads(content, cls=ConcatJSONDecoder)
+    except Exception as e:
+        raise Exception('Error while parsing JSON: {}'.format(repr(content)), e)
 
     rtn = [None]*(len(j))
     for x in j:

--- a/fbchat/graphql.py
+++ b/fbchat/graphql.py
@@ -146,8 +146,8 @@ def graphql_response_to_json(content):
     content = strip_to_json(content) # Usually only needed in some error cases
     try:
         j = json.loads(content, cls=ConcatJSONDecoder)
-    except Exception as e:
-        raise Exception('Error while parsing JSON: {}'.format(repr(content)), e)
+    except Exception:
+        raise FBchatException('Error while parsing JSON: {}'.format(repr(content)))
 
     rtn = [None]*(len(j))
     for x in j:

--- a/fbchat/graphql.py
+++ b/fbchat/graphql.py
@@ -31,7 +31,7 @@ def graphql_color_to_enum(color):
     try:
         return ThreadColor('#{}'.format(color[2:].lower()))
     except ValueError:
-        raise Exception('Could not get ThreadColor from color: {}'.format(color))
+        raise FBchatException('Could not get ThreadColor from color: {}'.format(color))
 
 def get_customization_info(thread):
     if thread is None or thread.get('customization_info') is None:
@@ -176,7 +176,7 @@ class GraphQL(object):
                 'query_params': params
             }
         else:
-            raise Exception('A query or doc_id must be specified')
+            raise FBchatUserError('A query or doc_id must be specified')
 
 
     FRAGMENT_USER = """

--- a/fbchat/models.py
+++ b/fbchat/models.py
@@ -4,6 +4,26 @@ from __future__ import unicode_literals
 import enum
 
 
+class FBchatException(Exception):
+    """Custom exception thrown by fbchat. All exceptions in the fbchat module inherits this"""
+
+class FBchatFacebookError(FBchatException):
+    #: The error code that Facebook returned
+    fb_error_code = str
+    #: The error message that Facebook returned (In the user's own language)
+    fb_error_message = str
+    #: The status code that was sent in the http response (eg. 404) (Usually only set if not successful, aka. not 200)
+    request_status_code = int
+    def __init__(self, message, fb_error_code=None, fb_error_message=None, request_status_code=None):
+        super(FBchatFacebookError, self).__init__(message)
+        """Thrown by fbchat when Facebook returns an error"""
+        self.fb_error_code = str(fb_error_code)
+        self.fb_error_message = fb_error_message
+        self.request_status_code = request_status_code
+
+class FBchatUserError(FBchatException):
+    """Thrown by fbchat when wrong values are entered"""
+
 class Thread(object):
     #: The unique identifier of the thread. Can be used a `thread_id`. See :ref:`intro_threads` for more info
     uid = str

--- a/fbchat/utils.py
+++ b/fbchat/utils.py
@@ -93,6 +93,16 @@ class ReqUrl(object):
     TYPING = "https://www.facebook.com/ajax/messaging/typ.php"
     GRAPHQL = "https://www.facebook.com/api/graphqlbatch/"
 
+    pull_channel = 0
+
+    def change_pull_channel(self, channel=None):
+        if channel is None:
+            self.pull_channel = (self.pull_channel + 1) % 5 # Pull channel will be 0-4
+        else:
+            self.pull_channel = channel
+        self.STICKY = "https://{}-edge-chat.facebook.com/pull".format(self.pull_channel)
+        self.PING = "https://{}-edge-chat.facebook.com/active_ping".format(self.pull_channel)
+
 
 facebookEncoding = 'UTF-8'
 
@@ -153,7 +163,7 @@ def check_json(j):
     else:
         raise FBchatFacebookError('Error {} when sending request'.format(j['error']), fb_error_code=j['error'])
 
-def checkRequest(r, do_json_check=True):
+def check_request(r, as_json=True):
     if not r.ok:
         raise FBchatFacebookError('Error when sending request: Got {} response'.format(r.status_code), request_error_code=r.status_code)
 
@@ -162,7 +172,7 @@ def checkRequest(r, do_json_check=True):
     if content is None or len(content) == 0:
         raise FBchatFacebookError('Error when sending request: Got empty response')
 
-    if do_json_check:
+    if as_json:
         content = strip_to_json(content)
         try:
             j = json.loads(content)

--- a/fbchat/utils.py
+++ b/fbchat/utils.py
@@ -165,7 +165,7 @@ def check_json(j):
 
 def check_request(r, as_json=True):
     if not r.ok:
-        raise FBchatFacebookError('Error when sending request: Got {} response'.format(r.status_code), request_error_code=r.status_code)
+        raise FBchatFacebookError('Error when sending request: Got {} response'.format(r.status_code), request_status_code=r.status_code)
 
     content = get_decoded_r(r)
 

--- a/fbchat/utils.py
+++ b/fbchat/utils.py
@@ -103,7 +103,7 @@ def strip_to_json(text):
     try:
         return text[text.index('{'):]
     except ValueError:
-        raise Exception('No JSON object found: {}, {}'.format(repr(text), text.index('{')))
+        raise FBchatException('No JSON object found: {}, {}'.format(repr(text), text.index('{')))
 
 def get_decoded_r(r):
     return get_decoded(r._content)
@@ -143,30 +143,31 @@ def generateOfflineThreadingID():
     return str(int(msgs, 2))
 
 def check_json(j):
-    if 'error' in j and j['error'] is not None:
-        if 'errorDescription' in j:
-            # 'errorDescription' is in the users own language!
-            raise Exception('Error #{} when sending request: {}'.format(j['error'], j['errorDescription']))
-        elif 'debug_info' in j['error']:
-            raise Exception('Error #{} when sending request: {}'.format(j['error']['code'], repr(j['error']['debug_info'])))
-        else:
-            raise Exception('Error {} when sending request'.format(j['error']))
+    if j.get('error') is None:
+        return
+    if 'errorDescription' in j:
+        # 'errorDescription' is in the users own language!
+        raise FBchatFacebookError('Error #{} when sending request: {}'.format(j['error'], j['errorDescription']), fb_error_code=j['error'], fb_error_message=j['errorDescription'])
+    elif 'debug_info' in j['error'] and 'code' in j['error']:
+        raise FBchatFacebookError('Error #{} when sending request: {}'.format(j['error']['code'], repr(j['error']['debug_info'])), fb_error_code=j['error']['code'], fb_error_message=j['error']['debug_info'])
+    else:
+        raise FBchatFacebookError('Error {} when sending request'.format(j['error']), fb_error_code=j['error'])
 
 def checkRequest(r, do_json_check=True):
     if not r.ok:
-        raise Exception('Error when sending request: Got {} response'.format(r.status_code))
+        raise FBchatFacebookError('Error when sending request: Got {} response'.format(r.status_code), request_error_code=r.status_code)
 
     content = get_decoded_r(r)
 
     if content is None or len(content) == 0:
-        raise Exception('Error when sending request: Got empty response')
+        raise FBchatFacebookError('Error when sending request: Got empty response')
 
     if do_json_check:
         content = strip_to_json(content)
         try:
             j = json.loads(content)
-        except Exception as e:
-            raise Exception('Error while parsing JSON: {}'.format(repr(content)), e)
+        except ValueError:
+            raise FBchatFacebookError('Error while parsing JSON: {}'.format(repr(content)))
         check_json(j)
         return j
     else:


### PR DESCRIPTION
#175 (502 response):
You would get either a 502 or a 503 response from Facebook's pull-servers once in a while.
Proposed fix is to change the pull-channel, and refresh the `self.sticky`/`self.pool` parameters.

I don't quite remember my tests, but I'm pretty sure that refreshing the sticky/pool parameters were nescessary. I'm not sure I actually double-checked that changing the pull-channel was nescessary, but it's something that I've noticed the Facebook-webclient does.

Other than that:
- The default `doOneListen` loop has been improved.
- Added custom exceptions `FBchatException`, `FBchatFacebookError` and `FBchatUserError`
- Using the custom exceptions, this fixes the "Please try closing and re-opening your browser window" error
- Changed `ReqUrl` to `self.req_url`, so that we can change pull channels

This is still untested for long amounts of time, will do that before merging