### PR TITLE
fixed all mutable default argument gotchas

### DIFF
--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -1567,7 +1567,7 @@ class Client(object):
         return True
 
 
-    def onMessage(self, mid=None, author_id=None, message=None, thread_id=None, thread_type=ThreadType.USER, ts=None, metadata=None, msg={}):
+    def onMessage(self, mid=None, author_id=None, message=None, thread_id=None, thread_type=ThreadType.USER, ts=None, metadata=None, msg=None):
         """
         Called when the client is listening, and somebody sends a message
 
@@ -1583,7 +1583,7 @@ class Client(object):
         """
         log.info("Message from {} in {} ({}): {}".format(author_id, thread_id, thread_type.name, message))
 
-    def onColorChange(self, mid=None, author_id=None, new_color=None, thread_id=None, thread_type=ThreadType.USER, ts=None, metadata=None, msg={}):
+    def onColorChange(self, mid=None, author_id=None, new_color=None, thread_id=None, thread_type=ThreadType.USER, ts=None, metadata=None, msg=None):
         """
         Called when the client is listening, and somebody changes a thread's color
 
@@ -1600,7 +1600,7 @@ class Client(object):
         """
         log.info("Color change from {} in {} ({}): {}".format(author_id, thread_id, thread_type.name, new_color))
 
-    def onEmojiChange(self, mid=None, author_id=None, new_emoji=None, thread_id=None, thread_type=ThreadType.USER, ts=None, metadata=None, msg={}):
+    def onEmojiChange(self, mid=None, author_id=None, new_emoji=None, thread_id=None, thread_type=ThreadType.USER, ts=None, metadata=None, msg=None):
         """
         Called when the client is listening, and somebody changes a thread's emoji
 
@@ -1616,7 +1616,7 @@ class Client(object):
         """
         log.info("Emoji change from {} in {} ({}): {}".format(author_id, thread_id, thread_type.name, new_emoji))
 
-    def onTitleChange(self, mid=None, author_id=None, new_title=None, thread_id=None, thread_type=ThreadType.USER, ts=None, metadata=None, msg={}):
+    def onTitleChange(self, mid=None, author_id=None, new_title=None, thread_id=None, thread_type=ThreadType.USER, ts=None, metadata=None, msg=None):
         """
         Called when the client is listening, and somebody changes the title of a thread
 
@@ -1632,7 +1632,7 @@ class Client(object):
         """
         log.info("Title change from {} in {} ({}): {}".format(author_id, thread_id, thread_type.name, new_title))
 
-    def onNicknameChange(self, mid=None, author_id=None, changed_for=None, new_nickname=None, thread_id=None, thread_type=ThreadType.USER, ts=None, metadata=None, msg={}):
+    def onNicknameChange(self, mid=None, author_id=None, changed_for=None, new_nickname=None, thread_id=None, thread_type=ThreadType.USER, ts=None, metadata=None, msg=None):
         """
         Called when the client is listening, and somebody changes the nickname of a person
 
@@ -1650,7 +1650,7 @@ class Client(object):
         log.info("Nickname change from {} in {} ({}) for {}: {}".format(author_id, thread_id, thread_type.name, changed_for, new_nickname))
 
 
-    def onMessageSeen(self, seen_by=None, thread_id=None, thread_type=ThreadType.USER, seen_ts=None, ts=None, metadata=None, msg={}):
+    def onMessageSeen(self, seen_by=None, thread_id=None, thread_type=ThreadType.USER, seen_ts=None, ts=None, metadata=None, msg=None):
         """
         Called when the client is listening, and somebody marks a message as seen
 
@@ -1665,7 +1665,7 @@ class Client(object):
         """
         log.info("Messages seen by {} in {} ({}) at {}s".format(seen_by, thread_id, thread_type.name, seen_ts/1000))
 
-    def onMessageDelivered(self, msg_ids=None, delivered_for=None, thread_id=None, thread_type=ThreadType.USER, ts=None, metadata=None, msg={}):
+    def onMessageDelivered(self, msg_ids=None, delivered_for=None, thread_id=None, thread_type=ThreadType.USER, ts=None, metadata=None, msg=None):
         """
         Called when the client is listening, and somebody marks messages as delivered
 
@@ -1680,7 +1680,7 @@ class Client(object):
         """
         log.info("Messages {} delivered to {} in {} ({}) at {}s".format(msg_ids, delivered_for, thread_id, thread_type.name, ts/1000))
 
-    def onMarkedSeen(self, threads=None, seen_ts=None, ts=None, metadata=None, msg={}):
+    def onMarkedSeen(self, threads=None, seen_ts=None, ts=None, metadata=None, msg=None):
         """
         Called when the client is listening, and the client has successfully marked threads as seen
 
@@ -1695,7 +1695,7 @@ class Client(object):
         log.info("Marked messages as seen in threads {} at {}s".format([(x[0], x[1].name) for x in threads], seen_ts/1000))
 
 
-    def onPeopleAdded(self, mid=None, added_ids=None, author_id=None, thread_id=None, ts=None, msg={}):
+    def onPeopleAdded(self, mid=None, added_ids=None, author_id=None, thread_id=None, ts=None, msg=None):
         """
         Called when the client is listening, and somebody adds people to a group thread
 
@@ -1708,7 +1708,7 @@ class Client(object):
         """
         log.info("{} added: {}".format(author_id, ', '.join(added_ids)))
 
-    def onPersonRemoved(self, mid=None, removed_id=None, author_id=None, thread_id=None, ts=None, msg={}):
+    def onPersonRemoved(self, mid=None, removed_id=None, author_id=None, thread_id=None, ts=None, msg=None):
         """
         Called when the client is listening, and somebody removes a person from a group thread
 
@@ -1721,7 +1721,7 @@ class Client(object):
         """
         log.info("{} removed: {}".format(author_id, removed_id))
 
-    def onFriendRequest(self, from_id=None, msg={}):
+    def onFriendRequest(self, from_id=None, msg=None):
         """
         Called when the client is listening, and somebody sends a friend request
 
@@ -1730,7 +1730,7 @@ class Client(object):
         """
         log.info("Friend request from {}".format(from_id))
 
-    def onInbox(self, unseen=None, unread=None, recent_unread=None, msg={}):
+    def onInbox(self, unseen=None, unread=None, recent_unread=None, msg=None):
         """
         .. todo::
             Documenting this
@@ -1742,7 +1742,7 @@ class Client(object):
         """
         log.info('Inbox event: {}, {}, {}'.format(unseen, unread, recent_unread))
 
-    def onQprimer(self, ts=None, msg={}):
+    def onQprimer(self, ts=None, msg=None):
         """
         Called when the client just started listening
 
@@ -1751,7 +1751,7 @@ class Client(object):
         """
         pass
 
-    def onChatTimestamp(self, buddylist={}, msg={}):
+    def onChatTimestamp(self, buddylist=None, msg=None):
         """
         Called when the client receives chat online presence update
 
@@ -1760,7 +1760,7 @@ class Client(object):
         """
         log.debug('Chat Timestamps received: {}'.format(buddylist))
 
-    def onUnknownMesssageType(self, msg={}):
+    def onUnknownMesssageType(self, msg=None):
         """
         Called when the client is listening, and some unknown data was recieved
 
@@ -1768,7 +1768,7 @@ class Client(object):
         """
         log.debug('Unknown message received: {}'.format(msg))
 
-    def onMessageError(self, exception=None, msg={}):
+    def onMessageError(self, exception=None, msg=None):
         """
         Called when an error was encountered while parsing recieved data
 

--- a/fbchat/graphql.py
+++ b/fbchat/graphql.py
@@ -167,7 +167,9 @@ def graphql_response_to_json(content):
     return rtn
 
 class GraphQL(object):
-    def __init__(self, query=None, doc_id=None, params={}):
+    def __init__(self, query=None, doc_id=None, params=None):
+        if params is None:
+            params = {}
         if query is not None:
             self.value = {
                 'priority': 0,

--- a/fbchat/models.py
+++ b/fbchat/models.py
@@ -100,10 +100,14 @@ class Group(Thread):
     #: The groups's default emoji
     emoji = str
 
-    def __init__(self, uid, participants=set(), nicknames=[], color=None, emoji=None, **kwargs):
+    def __init__(self, uid, participants=None, nicknames=None, color=None, emoji=None, **kwargs):
         """Represents a Facebook group. Inherits `Thread`"""
         super(Group, self).__init__(ThreadType.GROUP, uid, **kwargs)
+        if participants is None:
+            participants = set()
         self.participants = participants
+        if nicknames is None:
+            nicknames = []
         self.nicknames = nicknames
         self.color = color
         self.emoji = emoji
@@ -153,17 +157,25 @@ class Message(object):
     #: An extensible attachment, e.g. share object
     extensible_attachment = dict
 
-    def __init__(self, uid, author=None, timestamp=None, is_read=None, reactions=[], text=None, mentions=[], sticker=None, attachments=[], extensible_attachment={}):
+    def __init__(self, uid, author=None, timestamp=None, is_read=None, reactions=None, text=None, mentions=None, sticker=None, attachments=None, extensible_attachment=None):
         """Represents a Facebook message"""
         self.uid = uid
         self.author = author
         self.timestamp = timestamp
         self.is_read = is_read
+        if reactions is None:
+            reactions = []
         self.reactions = reactions
         self.text = text
+        if mentions is None:
+            mentions = []
         self.mentions = mentions
         self.sticker = sticker
+        if attachments is None:
+            attachments = []
         self.attachments = attachments
+        if extensible_attachment is None:
+            extensible_attachment = {}
         self.extensible_attachment = extensible_attachment
 
 


### PR DESCRIPTION
> Python’s default arguments are evaluated once when the function is defined, not each time the function is called. This means that if you use a mutable default argument and mutate it, you will and have mutated that object for all future calls to the function as well.

http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments