### PR TITLE
Change logging mode from DEBUG to INFO

### DIFF
--- a/fbchat/utils.py
+++ b/fbchat/utils.py
@@ -17,7 +17,7 @@ except NameError:
 
 # Log settings
 log = logging.getLogger("client")
-log.setLevel(logging.DEBUG)
+log.setLevel(logging.INFO)
 # Creates the console handler
 handler = logging.StreamHandler()
 log.addHandler(handler)


### PR DESCRIPTION
Debug mode caused many trash to get printed in the console, and passing logging level in class initiation didn't seem to fix it.