### PR TITLE
Use datetime objects rather than milliseconds as a string

### DIFF
--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -10,8 +10,8 @@ from mimetypes import guess_type
 from .utils import *
 from .models import *
 from .graphql import *
-import time
-
+from datetime import datetime
+import calendar
 
 
 class Client(object):
@@ -735,13 +735,15 @@ class Client(object):
         :param limit: Max. number of messages to retrieve
         :param before: A timestamp, indicating from which point to retrieve messages
         :type limit: int
-        :type before: int
+        :type before: datetime 
         :return: :class:`models.Message` objects
         :rtype: list
         :raises: FBchatException if request failed
         """
-
         thread_id, thread_type = self._getThread(thread_id, None)
+
+        if before is not None:
+            before = int(unix_time_millis(before))
 
         j = self.graphql_request(GraphQL(doc_id='1386147188135407', params={
             'id': thread_id,

--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -766,7 +766,7 @@ class Client(object):
         :param thread_location: models.ThreadLocation: INBOX, PENDING, ARCHIVED or OTHER
         :param before: A timestamp (in milliseconds), indicating from which point to retrieve threads
         :type limit: int
-        :type before: int
+        :type before: datetime
         :return: :class:`models.Thread` objects
         :rtype: list
         :raises: FBchatException if request failed
@@ -782,6 +782,9 @@ class Client(object):
             loc_str = thread_location.value
         else:
             raise FBchatUserError('"thread_location" must be a value of ThreadLocation')
+
+        if before is not None:
+            before = unix_time_millis(before) 
 
         j = self.graphql_request(GraphQL(doc_id='1349387578499440', params={
             'limit': limit,

--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -10,9 +10,7 @@ from mimetypes import guess_type
 from .utils import *
 from .models import *
 from .graphql import *
-from datetime import datetime
-import calendar
-
+import time
 
 class Client(object):
     """A client for the Facebook Chat (Messenger).

--- a/fbchat/graphql.py
+++ b/fbchat/graphql.py
@@ -143,9 +143,7 @@ def graphql_to_message(message):
     rtn.uid = str(message.get('message_id'))
     rtn.author = str(message.get('message_sender').get('id'))
     
-    # timestamp is a string of an int in milliseconds, so divide by 1000 and convert it 
-    timestamp_raw = float(message.get('timestamp_precise')) / 1000
-    rtn.timestamp = datetime.fromtimestamp(timestamp_raw)
+    rtn.timestamp = millis_to_datetime(message.get('timestamp_precise'))
 
     if message.get('unread') is not None:
         rtn.is_read = not message['unread']
@@ -188,7 +186,7 @@ def graphql_to_thread(thread):
         user = next(p for p in participants if p['id'] == thread['thread_key']['other_user_id'])
         last_message_timestamp = None
         if 'last_message' in thread:
-            last_message_timestamp = thread['last_message']['nodes'][0]['timestamp_precise']
+            last_message_timestamp = millis_to_datetime(thread['last_message']['nodes'][0]['timestamp_precise'])
 
         return User(
             user['id'],
@@ -216,7 +214,7 @@ def graphql_to_group(group):
     c_info = get_customization_info(group)
     last_message_timestamp = None
     if 'last_message' in group:
-        last_message_timestamp = group['last_message']['nodes'][0]['timestamp_precise']
+        last_message_timestamp = millis_to_datetime(group['last_message']['nodes'][0]['timestamp_precise'])
     return Group(
         group['thread_key']['thread_fbid'],
         participants=set([node['messaging_actor']['id'] for node in group['all_participants']['nodes']]),

--- a/fbchat/graphql.py
+++ b/fbchat/graphql.py
@@ -5,6 +5,7 @@ import json
 import re
 from .models import *
 from .utils import *
+from datetime import datetime
 
 # Shameless copy from https://stackoverflow.com/a/8730674
 FLAGS = re.VERBOSE | re.MULTILINE | re.DOTALL
@@ -141,7 +142,11 @@ def graphql_to_message(message):
     )
     rtn.uid = str(message.get('message_id'))
     rtn.author = str(message.get('message_sender').get('id'))
-    rtn.timestamp = message.get('timestamp_precise')
+    
+    # timestamp is a string of an int in milliseconds, so divide by 1000 and convert it 
+    timestamp_raw = int(message.get('timestamp_precise'))
+    rtn.timestamp = datetime.fromtimestamp(timestamp_raw / 1000)
+
     if message.get('unread') is not None:
         rtn.is_read = not message['unread']
     rtn.reactions = {str(r['user']['id']):MessageReaction(r['reaction']) for r in message.get('message_reactions')}

--- a/fbchat/graphql.py
+++ b/fbchat/graphql.py
@@ -144,8 +144,8 @@ def graphql_to_message(message):
     rtn.author = str(message.get('message_sender').get('id'))
     
     # timestamp is a string of an int in milliseconds, so divide by 1000 and convert it 
-    timestamp_raw = int(message.get('timestamp_precise'))
-    rtn.timestamp = datetime.fromtimestamp(timestamp_raw / 1000)
+    timestamp_raw = float(message.get('timestamp_precise')) / 1000
+    rtn.timestamp = datetime.fromtimestamp(timestamp_raw)
 
     if message.get('unread') is not None:
         rtn.is_read = not message['unread']

--- a/fbchat/utils.py
+++ b/fbchat/utils.py
@@ -240,3 +240,8 @@ def get_emojisize_from_tags(tags):
 
 def unix_time_millis(dt):
     return (dt - epoch).total_seconds() * 1000.0
+
+def millis_to_datetime(t):
+    if isinstance(t, str):
+        t = float(t)
+    return datetime.fromtimestamp(t / 1000.0)

--- a/fbchat/utils.py
+++ b/fbchat/utils.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 import re
 import json
+from datetime import datetime
 from time import time
 from random import random
 import warnings
@@ -28,6 +29,9 @@ log.setLevel(logging.DEBUG)
 # Creates the console handler
 handler = logging.StreamHandler()
 log.addHandler(handler)
+
+# Unix epoch
+epoch = datetime.utcfromtimestamp(0)
 
 #: Default list of user agents
 USER_AGENTS = [
@@ -233,3 +237,6 @@ def get_emojisize_from_tags(tags):
         except (KeyError, IndexError):
             log.exception('Could not determine emoji size from {} - {}'.format(tags, tmp))
     return None
+
+def unix_time_millis(dt):
+    return (dt - epoch).total_seconds() * 1000.0


### PR DESCRIPTION
*Fixes #277*

**Changes:**

  - `Message.timestamp` is now a datetime object
  - `Thread.last_message_timestamp` is now a datetime object
  - `before` parameter of `Client.fetchThreadMessages()` & `Client.fetchThreadList()` is now a datetime object
  - *Added `utils.unix_time_millis` and `utils.millis_to_datetime`*