### PR TITLE
Fix `IndexError: list index out of range` bug

### DIFF
--- a/fbchat/graphql.py
+++ b/fbchat/graphql.py
@@ -190,7 +190,7 @@ def graphql_to_thread(thread):
             url=user.get('url'),
             name=user.get('name'),
             first_name=user.get('short_name'),
-            last_name=user.get('name').split(user.get('short_name'),1)[1].strip(),
+            last_name=user.get('name').split(user.get('short_name'),1).pop().strip(),
             is_friend=user.get('is_viewer_friend'),
             gender=GENDERS.get(user.get('gender')),
             affinity=user.get('affinity'),


### PR DESCRIPTION
When the returned `short_name` is null, `fbchat` throws an exception:

```python
  File "/usr/local/lib/python2.7/site-packages/fbchat/client.py", line 792, in fetchThreadList
    return [graphql_to_thread(node) for node in j['viewer']['message_threads']['nodes']]
  File "/usr/local/lib/python2.7/site-packages/fbchat/graphql.py", line 193, in graphql_to_thread
    last_name=user.get('name').split(user.get('short_name'),1)[1].strip(),
IndexError: list index out of range
```

This commit fixes that scenario by accessing the last item in the list via `.pop()` instead of via `[1]`