### PR TITLE
Eliminate an unnecessary HTTP request during login

### DIFF
--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -138,8 +138,9 @@ class Client(object):
                 return self._graphql(payload, error_retries=error_retries-1)
             raise e
 
-    def _cleanGet(self, url, query=None, timeout=30):
-        return self._session.get(url, headers=self._header, params=query, timeout=timeout, verify=self.ssl_verify)
+    def _cleanGet(self, url, query=None, timeout=30, allow_redirects=True):
+        return self._session.get(url, headers=self._header, params=query, timeout=timeout, verify=self.ssl_verify,
+                                 allow_redirects=allow_redirects)
 
     def _cleanPost(self, url, query=None, timeout=30):
         self.req_counter += 1
@@ -325,8 +326,8 @@ class Client(object):
         :rtype: bool
         """
         # Send a request to the login url, to see if we're directed to the home page
-        r = self._cleanGet(self.req_url.LOGIN)
-        return 'home' in r.url
+        r = self._cleanGet(self.req_url.LOGIN, allow_redirects=False)
+        return 'home' in r.headers['Location']
 
     def getSession(self):
         """Retrieves session cookies


### PR DESCRIPTION
This change eliminates requesting and downloading the entire FB home page (~160kb) every login.

Another HTTP request can be eliminated when logging in using session cookies by removing ` or not self.isLoggedIn()` from line 74 of client.py, because if the session_cookies are not valid, `setSession()` would surely return False, because of the many exceptions that `_postLogin()` will be throwing.

What do you think?