### PR TITLE
Added missing color

### DIFF
--- a/fbchat/models.py
+++ b/fbchat/models.py
@@ -480,6 +480,7 @@ class ThreadColor(Enum):
     LIGHT_CORAL = '#e68585'
     MEDIUM_SLATE_BLUE = '#7646ff'
     DEEP_SKY_BLUE = '#20cef5'
+    DARK_BLUE = '#00c517'
     FERN = '#67b868'
     CAMEO = '#d4a88c'
     BRILLIANT_ROSE = '#ff5ca1'


### PR DESCRIPTION
This fixes `models.FBchatException: Could not get ThreadColor from color: FF00C517` exception that I ran into while trying to use this library.