### PR TITLE
Fix onTyping detection

### DIFF
--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -1529,9 +1529,9 @@ class Client(object):
                     self.onInbox(unseen=m["unseen"], unread=m["unread"], recent_unread=m["recent_unread"], msg=m)
 
                 # Typing
-                elif mtype == "typ":
+                elif mtype == "ttyp":
                     author_id = str(m.get("from"))
-                    thread_id = str(m.get("to"))
+                    thread_id = str(m.get("thread_fbid"))
                     if thread_id == self.uid:
                         thread_type = ThreadType.USER
                     else:

--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -1531,11 +1531,16 @@ class Client(object):
                 # Typing
                 elif mtype == "typ" or mtype == "ttyp":
                     author_id = str(m.get("from"))
-                    thread_id = str(m.get("thread_fbid"))
-                    if thread_id == self.uid:
-                        thread_type = ThreadType.USER
-                    else:
+                    thread_id = m.get("thread_fbid")
+                    if thread_id:
                         thread_type = ThreadType.GROUP
+                        thread_id = str(thread_id)
+                    else:
+                        thread_type = ThreadType.USER
+                        if author_id == self.uid:
+                            thread_id = m.get("to")
+                        else:
+                            thread_id = author_id
                     typing_status = TypingStatus(m.get("st"))
                     self.onTyping(author_id=author_id, status=typing_status, thread_id=thread_id, thread_type=thread_type, msg=m)
 

--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -1529,7 +1529,7 @@ class Client(object):
                     self.onInbox(unseen=m["unseen"], unread=m["unread"], recent_unread=m["recent_unread"], msg=m)
 
                 # Typing
-                elif mtype == "ttyp":
+                elif mtype == "typ" or mtype == "ttyp":
                     author_id = str(m.get("from"))
                     thread_id = str(m.get("thread_fbid"))
                     if thread_id == self.uid:

--- a/tests/test_thread_interraction.py
+++ b/tests/test_thread_interraction.py
@@ -103,10 +103,8 @@ def test_change_color_invalid(client):
     client.changeThreadColor(InvalidColor())
 
 
-@pytest.mark.xfail(reason="Apparently onTyping is broken")
 @pytest.mark.parametrize("status", TypingStatus)
 def test_typing_status(client, catch_event, compare, status):
     with catch_event("onTyping") as x:
         client.setTypingStatus(status)
-        # x.wait(40)
     assert compare(x, status=status)


### PR DESCRIPTION
FB changed the format of typing notification messages:
- update "mtype" from "typ" to "ttyp".
- Get thread ID from "to" to "thread_fbid" ("thread" looks the same)