### PR TITLE
Replace lxml with Python's built in html.parser

### DIFF
--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -209,7 +209,7 @@ class Client(object):
         self.ttstamp = ''
 
         r = self._get(self.req_url.BASE)
-        soup = bs(r.text, "lxml")
+        soup = bs(r.text, "html.parser")
 
         fb_dtsg_element = soup.find("input", {'name': 'fb_dtsg'})
         if fb_dtsg_element:
@@ -252,7 +252,7 @@ class Client(object):
         if not (self.email and self.password):
             raise FBchatUserError("Email and password not found.")
 
-        soup = bs(self._get(self.req_url.MOBILE).text, "lxml")
+        soup = bs(self._get(self.req_url.MOBILE).text, "html.parser")
         data = dict((elem['name'], elem['value']) for elem in soup.findAll("input") if elem.has_attr('value') and elem.has_attr('name'))
         data['email'] = self.email
         data['pass'] = self.password
@@ -277,7 +277,7 @@ class Client(object):
             return False, r.url
 
     def _2FA(self, r):
-        soup = bs(r.text, "lxml")
+        soup = bs(r.text, "html.parser")
         data = dict()
 
         s = self.on2FACode()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests
-lxml
 beautifulsoup4
 enum34; python_version < '3.4'
 six

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ with open('README.rst') as f:
 
 requirements = [
     'requests',
-    'lxml',
     'beautifulsoup4'
 ]
 


### PR DESCRIPTION
After my server has been running for some time, fbchat starts throwing the following exception:
```
Failed loading session
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/fbchat/client.py", line 366, in setSession
    self._postLogin()
  File "/usr/local/lib/python2.7/dist-packages/fbchat/client.py", line 212, in _postLogin
    soup = bs(r.text, "lxml")
  File "/usr/lib/python2.7/dist-packages/bs4/__init__.py", line 215, in __init__
    self._feed()
  File "/usr/lib/python2.7/dist-packages/bs4/__init__.py", line 239, in _feed
    self.builder.feed(self.markup)
  File "/usr/lib/python2.7/dist-packages/bs4/builder/_lxml.py", line 240, in feed
    self.parser.feed(markup)
  File "src/lxml/parser.pxi", line 1194, in lxml.etree._FeedParser.feed (src/lxml/lxml.etree.c:119773)
  File "src/lxml/parser.pxi", line 1237, in lxml.etree._FeedParser.feed (src/lxml/lxml.etree.c:118685)
  File "src/lxml/parser.pxi", line 827, in lxml.etree._BaseParser._getPushParserContext (src/lxml/lxml.etree.c:113960)
  File "src/lxml/parser.pxi", line 844, in lxml.etree._BaseParser._createContext (src/lxml/lxml.etree.c:114186)
  File "src/lxml/parsertarget.pxi", line 110, in lxml.etree._TargetParserContext._setTarget (src/lxml/
  File "src/lxml/parsertarget.pxi", line 41, in lxml.etree._PythonSaxParserTarget.__cinit__ (src/lxml/
  File "/usr/lib/python2.7/inspect.py", line 814, in getargspec
    func = func.im_func
RuntimeError: restricted attribute
```

Restarting the server fixes the problem temporarily, but it returns after a while.

[Researching the issue](https://www.google.com/search?q=%22func+%3D+func.im_func%22+%22RuntimeError%3A+restricted+attribute%22) brought up this problem being reported several times and considered "The unpredictable BS behavior again."
[![image](https://user-images.githubusercontent.com/168856/41414726-806674f6-6fef-11e8-8fda-243d7c0dd19b.png)](https://translate.googleusercontent.com/translate_c?act=url&depth=1&hl=en&ie=UTF8&prev=_t&rurl=translate.google.com&sl=auto&sp=nmt4&tl=en&u=https://github.com/72ka/plugin.video.dmd-czech.playtvak/issues/2&xid=17259,15700021,15700124,15700149,15700168,15700173,15700186,15700191,15700201&usg=ALkJrhh3yinyzBqWtK3x0lJWv4LkWcLEAA)

The only remedy being offered is replacing lxml.

This pull request replaces lxml with [Python's built in html.parser](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#installing-a-parser).