### PR TITLE
Fix: Name edge case results in IndexError

### DIFF
--- a/fbchat/graphql.py
+++ b/fbchat/graphql.py
@@ -185,12 +185,18 @@ def graphql_to_thread(thread):
         if 'last_message' in thread:
             last_message_timestamp = thread['last_message']['nodes'][0]['timestamp_precise']
 
+        first_name = user.get('short_name')
+        if first_name is None:
+            last_name = None
+        else:
+            last_name = user.get('name').split(first_name, 1).pop().strip()
+
         return User(
             user['id'],
             url=user.get('url'),
             name=user.get('name'),
-            first_name=user.get('short_name'),
-            last_name=user.get('name').split(user.get('short_name'),1).pop().strip(),
+            first_name=first_name,
+            last_name=last_name,
             is_friend=user.get('is_viewer_friend'),
             gender=GENDERS.get(user.get('gender')),
             affinity=user.get('affinity'),


### PR DESCRIPTION
There is an edge case for what I believe is deleted accounts where the _name_ attribute is an empty string and the _short_name_ attribute is None, which will result in an IndexError:

```
/anaconda3/lib/python3.6/site-packages/fbchat/graphql.py in graphql_to_thread(thread)
    193             name=user.get('name'),
    194             first_name=user.get('short_name'),
--> 195             last_name=user.get('name').split(user.get('short_name'),1).pop().strip(),
    196             is_friend=user.get('is_viewer_friend'),
    197             gender=GENDERS.get(user.get('gender')),

IndexError: pop from empty list
```