### PR TITLE
Fix enums

### DIFF
--- a/fbchat/graphql.py
+++ b/fbchat/graphql.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 import json
 import re
-import aenum
 from .models import *
 from .utils import *
 
@@ -23,14 +22,6 @@ class ConcatJSONDecoder(json.JSONDecoder):
             objs.append(obj)
         return objs
 # End shameless copy
-
-def enum_extend_if_invalid(enumeration, value):
-    try:
-        return enumeration(value)
-    except ValueError:
-        log.warning("Failed parsing {}({!r}). Extending enum.".format(enumeration, value))
-        aenum.extend_enum(enumeration, "UNKNOWN_{}".format(value).upper(), value)
-        return enumeration(value)
 
 def graphql_color_to_enum(color):
     if color is None:

--- a/fbchat/models.py
+++ b/fbchat/models.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 
 from __future__ import unicode_literals
-import enum
+import aenum
 
 
 class FBchatException(Exception):
@@ -523,7 +523,7 @@ class Plan(object):
     def __unicode__(self):
         return '<Plan ({}): {} time={}, location={}, location_id={}>'.format(self.uid, repr(self.title), self.time, repr(self.location), repr(self.location_id))
 
-class Enum(enum.Enum):
+class Enum(aenum.Enum):
     """Used internally by fbchat to support enumerations"""
     def __repr__(self):
         # For documentation:

--- a/fbchat/utils.py
+++ b/fbchat/utils.py
@@ -11,6 +11,7 @@ from os.path import basename
 import warnings
 import logging
 import requests
+import aenum
 from .models import *
 
 try:
@@ -297,3 +298,12 @@ def get_files_from_paths(filenames):
     yield files
     for fn, fp, ft in files:
         fp.close()
+
+
+def enum_extend_if_invalid(enumeration, value):
+    try:
+        return enumeration(value)
+    except ValueError:
+        log.warning("Failed parsing {}({!r}). Extending enum.".format(enumeration, value))
+        aenum.extend_enum(enumeration, "UNKNOWN_{}".format(value).upper(), value)
+        return enumeration(value)

--- a/fbchat/utils.py
+++ b/fbchat/utils.py
@@ -304,6 +304,6 @@ def enum_extend_if_invalid(enumeration, value):
     try:
         return enumeration(value)
     except ValueError:
-        log.warning("Failed parsing {}({!r}). Extending enum.".format(enumeration, value))
+        log.warning("Failed parsing {.__name__}({!r}). Extending enum.".format(enumeration, value))
         aenum.extend_enum(enumeration, "UNKNOWN_{}".format(value).upper(), value)
         return enumeration(value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
 beautifulsoup4
-enum34; python_version < '3.4'
+aenum

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,9 +43,6 @@ include_package_data = True
 packages = find:
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4.0
 install_requires =
+    aenum
     requests
     beautifulsoup4
-    # May not work in pip with bdist_wheel
-    # See https://wheel.readthedocs.io/en/latest/#defining-conditional-dependencies
-    # It is therefore defined in setup.py
-    # enum34; python_version < '3.4'

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,4 @@ from __future__ import unicode_literals
 
 from setuptools import setup
 
-setup(extras_require={':python_version < "3.4"': ['enum34']})
+setup()


### PR DESCRIPTION
Should fix #220 and fix #368. `changeThreadColor` and `reactToMessage` are not aware of this change yet.

I'm having trouble with Python 2.7 encoding. Narrowed it down to:
```py
tree = '🎄'
u"abc_{}".format(tree)
```
If we can figure the encoding errors, we might be able to solve #302?