### PR TITLE
Automatic GitHub Releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
       file_glob: true
       file: dist/*
       skip_cleanup: true
+      draft: true
       on:
         tags: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,20 @@ jobs:
   - python: pypy
 
   - stage: deploy
+    name: Github Releases
+    if: tag IS present
+    install: skip
+    script: flit build
+    deploy:
+      provider: releases
+      api_key: $GITHUB_OAUTH_TOKEN
+      file_glob: true
+      file: dist/*
+      skip_cleanup: true
+      on:
+        tags: true
+
+  - stage: deploy
     name: PyPI
     if: tag IS present
     install: skip


### PR DESCRIPTION
Now we automatically deploy a draft to GitHub Releases on new tags. This is mostly a shortcut for uploading the source and `wheel` distributions