### PR TITLE
Correct fetchUnread and fetchUnseen to include 1:1 chats and group chats

### DIFF
--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -1180,7 +1180,9 @@ class Client(object):
             self.req_url.UNREAD_THREADS, form, fix_request=True, as_json=True
         )
 
-        return j["payload"]["unread_thread_fbids"][0]["other_user_fbids"]
+        payload = j["payload"]["unread_thread_fbids"][0]
+
+        return payload['thread_fbids'] + payload['other_user_fbids']
 
     def fetchUnseen(self):
         """
@@ -1194,7 +1196,9 @@ class Client(object):
             self.req_url.UNSEEN_THREADS, None, fix_request=True, as_json=True
         )
 
-        return j["payload"]["unseen_thread_fbids"][0]["other_user_fbids"]
+        payload = j["payload"]["unseen_thread_fbids"][0]
+
+        return payload['thread_fbids'] + payload['other_user_fbids']
 
     def fetchImageUrl(self, image_id):
         """Fetches the url to the original image from an image attachment ID

--- a/fbchat/client.py
+++ b/fbchat/client.py
@@ -1182,7 +1182,7 @@ class Client(object):
 
         payload = j["payload"]["unread_thread_fbids"][0]
 
-        return payload['thread_fbids'] + payload['other_user_fbids']
+        return payload["thread_fbids"] + payload["other_user_fbids"]
 
     def fetchUnseen(self):
         """
@@ -1198,7 +1198,7 @@ class Client(object):
 
         payload = j["payload"]["unseen_thread_fbids"][0]
 
-        return payload['thread_fbids'] + payload['other_user_fbids']
+        return payload["thread_fbids"] + payload["other_user_fbids"]
 
     def fetchImageUrl(self, image_id):
         """Fetches the url to the original image from an image attachment ID


### PR DESCRIPTION
Currently, fetchUnread() and fetchUnseen() only include 1:1 threads, and not group threads.

Example response from Facebook:

```
{
   '__ar':1,
   'payload':{
      'unread_thread_fbids':[
         {
            'thread_fbids':[
               '[redacted]' // <= Group chats
            ],
            'other_user_fbids':[
               '[redacted]' // <= 1:1 chats
            ],
            'thread_ids':[
               '[redacted]',
               '[redacted]'
            ],
            'folder':'inbox'
         }
      ],
      'payload_source':'server_unread_threads'
   },
   'bootloadable':{},
   'ixData':{ },
   'bxData':{},
   'gkxData':{},
   'qexData':{},
   'lid':'[redacted]'}
``` 

This pull request changes the behavior of fetchUnseen() and fetchUnread() to include both.