### PR TITLE
Documentation improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,8 +21,8 @@ Traceback (most recent call last):
   File "[site-packages]/fbchat/client.py", line 78, in __init__
     self.login(email, password, max_tries)
   File "[site-packages]/fbchat/client.py", line 407, in login
-    raise FBchatUserError('Login failed. Check email/password. (Failed on url: {})'.format(login_url))
-fbchat.models.FBchatUserError: Login failed. Check email/password. (Failed on url: https://m.facebook.com/login.php?login_attempt=1)
+    raise FBchatUserError('Login failed. Check email/password. (Failed on URL: {})'.format(login_url))
+fbchat.models.FBchatUserError: Login failed. Check email/password. (Failed on URL: https://m.facebook.com/login.php?login_attempt=1)
 ```
 
 ## Environment information

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
     script: black --check --verbose .
 
   - stage: deploy
-    name: Github Releases
+    name: GitHub Releases
     if: tag IS present
     install: skip
     script: flit build

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,5 +1,5 @@
-Contributing to fbchat
-======================
+Contributing to ``fbchat``
+==========================
 
 Thanks for reading this, all contributions are very much welcome!
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-fbchat: Facebook Chat (Messenger) for Python
-============================================
+``fbchat``: Facebook Chat (Messenger) for Python
+================================================
 
 .. image:: https://img.shields.io/badge/license-BSD-blue.svg
     :target: https://github.com/carpedm20/fbchat/tree/master/LICENSE

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,8 +95,6 @@ html_theme_options = {
     "show_related": False,
 }
 
-html_extra_path = ["robots.txt"]
-
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
+    "sphinxcontrib.spelling",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -195,3 +196,15 @@ napoleon_numpy_docstring = False
 # napoleon_use_admonition_for_examples = False
 # napoleon_use_admonition_for_notes = False
 # napoleon_use_admonition_for_references = False
+
+# -- Options for spelling extension ----------------------------------------------
+
+spelling_word_list_filename = [
+    "spelling/names.txt",
+    "spelling/technical.txt",
+    "spelling/fixes.txt",
+]
+spelling_ignore_wiki_words = False
+# spelling_ignore_acronyms = False
+spelling_ignore_python_builtins = False
+spelling_ignore_importable_modules = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -184,3 +185,13 @@ intersphinx_mapping = {"https://docs.python.org/": None}
 todo_include_todos = True
 
 todo_link_only = True
+
+# -- Options for napoleon extension ----------------------------------------------
+
+# Use Google style docstrings
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
+
+# napoleon_use_admonition_for_examples = False
+# napoleon_use_admonition_for_notes = False
+# napoleon_use_admonition_for_references = False

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -30,8 +30,8 @@ This will show the different ways of fetching information about users and thread
 .. literalinclude:: ../examples/fetch.py
 
 
-Echobot
--------
+``Echobot``
+-----------
 
 This will reply to any message with the same message
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -9,7 +9,7 @@ Version X broke my installation
 We try to provide backwards compatibility where possible, but since we're not part of Facebook,
 most of the things may be broken at any point in time
 
-Downgrade to an earlier version of fbchat, run this command
+Downgrade to an earlier version of ``fbchat``, run this command
 
 .. code-block:: sh
 
@@ -28,7 +28,7 @@ Submitting Issues
 -----------------
 
 If you're having trouble with some of the snippets, or you think some of the functionality is broken,
-please feel free to submit an issue on `Github <https://github.com/carpedm20/fbchat>`_.
+please feel free to submit an issue on `GitHub <https://github.com/carpedm20/fbchat>`_.
 You should first login with ``logging_level`` set to ``logging.DEBUG``::
 
     from fbchat import Client

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,8 +6,8 @@
 .. This documentation's layout is heavily inspired by requests' layout: https://requests.readthedocs.io
    Some documentation is also partially copied from facebook-chat-api: https://github.com/Schmavery/facebook-chat-api
 
-fbchat: Facebook Chat (Messenger) for Python
-============================================
+``fbchat``: Facebook Chat (Messenger) for Python
+================================================
 
 Release v\ |version|. (:ref:`install`)
 
@@ -35,7 +35,7 @@ This means doing the exact same GET/POST requests and tricking Facebook into thi
 Therefore, this API requires the credentials of a Facebook account.
 
 .. note::
-    If you're having problems, please check the :ref:`faq`, before asking questions on Github
+    If you're having problems, please check the :ref:`faq`, before asking questions on GitHub
 
 .. warning::
     We are not responsible if your account gets banned for spammy activities,
@@ -44,7 +44,7 @@ Therefore, this API requires the credentials of a Facebook account.
 
 .. note::
     Facebook now has an `official API <https://developers.facebook.com/docs/messenger-platform>`_ for chat bots,
-    so if you're familiar with node.js, this might be what you're looking for.
+    so if you're familiar with ``Node.js``, this might be what you're looking for.
 
 If you're already familiar with the basics of how Facebook works internally, go to :ref:`examples` to see example usage of ``fbchat``
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,10 +3,10 @@
 Installation
 ============
 
-Pip Install fbchat
-------------------
+Install using pip
+-----------------
 
-To install fbchat, run this command:
+To install ``fbchat``, run this command:
 
 .. code-block:: sh
 
@@ -19,7 +19,7 @@ can guide you through the process.
 Get the Source Code
 -------------------
 
-fbchat is developed on GitHub, where the code is
+``fbchat`` is developed on GitHub, where the code is
 `always available <https://github.com/carpedm20/fbchat>`_.
 
 You can either clone the public repository:

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -24,7 +24,7 @@ Replace ``<email>`` and ``<password>`` with your email and password respectively
 
 .. note::
     For ease of use then most of the code snippets in this document will assume you've already completed the login process
-    Though the second line, ``from fbchat.models import *``, is not strictly neccesary here, later code snippets will assume you've done this
+    Though the second line, ``from fbchat.models import *``, is not strictly necessary here, later code snippets will assume you've done this
 
 If you want to change how verbose ``fbchat`` is, change the logging level (in :class:`Client`)
 
@@ -125,8 +125,8 @@ The following snippet will search for users by their name, take the first (and m
     user = users[0]
     print("User's ID: {}".format(user.uid))
     print("User's name: {}".format(user.name))
-    print("User's profile picture url: {}".format(user.photo))
-    print("User's main url: {}".format(user.url))
+    print("User's profile picture URL: {}".format(user.photo))
+    print("User's main URL: {}".format(user.url))
 
 Since this uses Facebook's search functions, you don't have to specify the whole name, first names will usually be enough
 
@@ -154,7 +154,7 @@ Or you can set the ``session_cookies`` on your initial login.
     client = Client('<email>', '<password>', session_cookies=session_cookies)
 
 .. warning::
-    You session cookies can be just as valueable as you password, so store them with equal care
+    You session cookies can be just as valuable as you password, so store them with equal care
 
 
 .. _intro_events:
@@ -192,7 +192,7 @@ The change was in the parameters that our `onMessage` method took: ``message_obj
 and ``mid``, ``ts``, ``metadata`` and ``msg`` got removed, but the function still works, since we included ``**kwargs``
 
 .. note::
-    Therefore, for both backwards and forwards compatability,
+    Therefore, for both backwards and forwards compatibility,
     the API actually requires that you include ``**kwargs`` as your final argument.
 
 View the :ref:`examples` to see some more examples illustrating the event system

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /en/master/

--- a/docs/spelling/fixes.txt
+++ b/docs/spelling/fixes.txt
@@ -1,0 +1,3 @@
+premade
+todo
+emoji

--- a/docs/spelling/names.txt
+++ b/docs/spelling/names.txt
@@ -1,0 +1,3 @@
+Facebook
+GraphQL
+GitHub

--- a/docs/spelling/technical.txt
+++ b/docs/spelling/technical.txt
@@ -1,0 +1,14 @@
+iterables
+timestamp
+metadata
+spam
+spammy
+admin
+admins
+unsend
+unsends
+unmute
+spritemap
+online
+inbox
+subclassing

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -9,11 +9,11 @@ This page will be periodically updated to show missing features and documentatio
 Missing Functionality
 ---------------------
 
-- Implement Client.searchForMessage
-    - This will use the graphql request API
+- Implement ``Client.searchForMessage``
+    - This will use the GraphQL request API
 - Implement chatting with pages properly
 - Write better FAQ
-- Explain usage of graphql
+- Explain usage of GraphQL
 
 
 Documentation

--- a/examples/interract.py
+++ b/examples/interract.py
@@ -47,7 +47,7 @@ client.sendLocalImage(
     thread_type=thread_type,
 )
 
-# Will download the image at the url `<image url>`, and then send it
+# Will download the image at the URL `<image url>`, and then send it
 client.sendRemoteImage(
     "<image url>",
     message=Message(text="This is a remote image"),

--- a/fbchat/_attachment.py
+++ b/fbchat/_attachment.py
@@ -20,7 +20,7 @@ class UnsentMessage(Attachment):
 
 @attr.s(cmp=False)
 class ShareAttachment(Attachment):
-    """Represents a shared item (eg. URL) attachment."""
+    """Represents a shared item (e.g. URL) attachment."""
 
     #: ID of the author of the shared post
     author = attr.ib(None)

--- a/fbchat/_attachment.py
+++ b/fbchat/_attachment.py
@@ -7,7 +7,7 @@ from . import _util
 
 @attr.s(cmp=False)
 class Attachment(object):
-    """Represents a Facebook attachment"""
+    """Represents a Facebook attachment."""
 
     #: The attachment ID
     uid = attr.ib(None)
@@ -15,12 +15,12 @@ class Attachment(object):
 
 @attr.s(cmp=False)
 class UnsentMessage(Attachment):
-    """Represents an unsent message attachment"""
+    """Represents an unsent message attachment."""
 
 
 @attr.s(cmp=False)
 class ShareAttachment(Attachment):
-    """Represents a shared item (eg. URL) that has been sent as a Facebook attachment"""
+    """Represents a shared item (eg. URL) attachment."""
 
     #: ID of the author of the shared post
     author = attr.ib(None)

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -81,7 +81,9 @@ class Client(object):
             max_tries (int): Maximum number of times to try logging in
             session_cookies (dict): Cookies from a previous session (Will default to login if these are invalid)
             logging_level (int): Configures the `logging level <https://docs.python.org/3/library/logging.html#logging-levels>`_. Defaults to ``logging.INFO``
-        :raises: FBchatException on failed login
+
+        Raises:
+            FBchatException: On failed login
         """
         self._sticky, self._pool = (None, None)
         self._seq = "0"
@@ -169,10 +171,11 @@ class Client(object):
 
         Args:
             queries (dict): Zero or more dictionaries
-
-        :raises: FBchatException if request failed
         :return: A tuple containing json graphql queries
         :rtype: tuple
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {
             "method": "GET",
@@ -184,7 +187,8 @@ class Client(object):
     def graphql_request(self, query):
         """Shorthand for ``graphql_requests(query)[0]``.
 
-        :raises: FBchatException if request failed
+        Raises:
+            FBchatException: If request failed
         """
         return self.graphql_requests(query)[0]
 
@@ -243,7 +247,9 @@ class Client(object):
             email: Facebook ``email`` or ``id`` or ``phone number``
             password: Facebook account password
             max_tries (int): Maximum number of times to try logging in
-        :raises: FBchatException on failed login
+
+        Raises:
+            FBchatException: On failed login
         """
         self.onLoggingIn(email=email)
 
@@ -298,9 +304,11 @@ class Client(object):
     def _getThread(self, given_thread_id=None, given_thread_type=None):
         """Check if thread ID is given and if default is set, and return correct values.
 
-        :raises ValueError: If thread ID is not given and there is no default
         :return: Thread ID and thread type
         :rtype: tuple
+
+        Raises:
+            ValueError: If thread ID is not given and there is no default
         """
         if given_thread_id is None:
             if self._default_thread_id is not None:
@@ -348,7 +356,9 @@ class Client(object):
             limit: The max. amount of threads to fetch (default all threads)
         :return: :class:`Thread` objects
         :rtype: list
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         threads = []
 
@@ -397,7 +407,9 @@ class Client(object):
             threads: Thread: List of threads to check for users
         :return: :class:`User` objects
         :rtype: list
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         users = []
         users_to_fetch = []  # It's more efficient to fetch all users in one request
@@ -421,7 +433,9 @@ class Client(object):
 
         :return: :class:`User` objects
         :rtype: list
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {"viewer": self._uid}
         j = self._payload_post("/chat/user_info_all", data)
@@ -443,7 +457,9 @@ class Client(object):
             limit: The max. amount of users to fetch
         :return: :class:`User` objects, ordered by relevance
         :rtype: list
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         params = {"search": name, "limit": limit}
         j = self.graphql_request(_graphql.from_query(_graphql.SEARCH_USER, params))
@@ -457,7 +473,9 @@ class Client(object):
             name: Name of the page
         :return: :class:`Page` objects, ordered by relevance
         :rtype: list
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         params = {"search": name, "limit": limit}
         j = self.graphql_request(_graphql.from_query(_graphql.SEARCH_PAGE, params))
@@ -472,7 +490,9 @@ class Client(object):
             limit: The max. amount of groups to fetch
         :return: :class:`Group` objects, ordered by relevance
         :rtype: list
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         params = {"search": name, "limit": limit}
         j = self.graphql_request(_graphql.from_query(_graphql.SEARCH_GROUP, params))
@@ -487,7 +507,9 @@ class Client(object):
             limit: The max. amount of groups to fetch
         :return: :class:`User`, :class:`Group` and :class:`Page` objects, ordered by relevance
         :rtype: list
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         params = {"search": name, "limit": limit}
         j = self.graphql_request(_graphql.from_query(_graphql.SEARCH_THREAD, params))
@@ -521,7 +543,9 @@ class Client(object):
             thread_id: User/Group ID to search in. See :ref:`intro_threads`
         :return: Found Message IDs
         :rtype: typing.Iterable
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
 
@@ -552,7 +576,9 @@ class Client(object):
             thread_id: User/Group ID to search in. See :ref:`intro_threads`
         :return: Found :class:`Message` objects
         :rtype: typing.Iterable
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         message_ids = self.searchForMessageIDs(
             query, offset=offset, limit=limit, thread_id=thread_id
@@ -570,7 +596,9 @@ class Client(object):
             message_limit (int): Max. number of messages to retrieve
         :return: Dictionary with thread IDs as keys and iterables to get messages as values
         :rtype: typing.Dict[str, typing.Iterable]
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {"query": query, "snippetLimit": thread_limit}
         j = self._payload_post("/ajax/mercury/search_snippets.php?dpr=1", data)
@@ -636,7 +664,9 @@ class Client(object):
             user_ids: One or more user ID(s) to query
         :return: :class:`User` objects, labeled by their ID
         :rtype: dict
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         threads = self.fetchThreadInfo(*user_ids)
         users = {}
@@ -658,7 +688,9 @@ class Client(object):
             page_ids: One or more page ID(s) to query
         :return: :class:`Page` objects, labeled by their ID
         :rtype: dict
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         threads = self.fetchThreadInfo(*page_ids)
         pages = {}
@@ -677,7 +709,9 @@ class Client(object):
             group_ids: One or more group ID(s) to query
         :return: :class:`Group` objects, labeled by their ID
         :rtype: dict
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         threads = self.fetchThreadInfo(*group_ids)
         groups = {}
@@ -699,7 +733,9 @@ class Client(object):
             thread_ids: One or more thread ID(s) to query
         :return: :class:`Thread` objects, labeled by their ID
         :rtype: dict
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         queries = []
         for thread_id in thread_ids:
@@ -762,7 +798,9 @@ class Client(object):
             before (int): A timestamp, indicating from which point to retrieve messages
         :return: :class:`Message` objects
         :rtype: list
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
 
@@ -805,7 +843,9 @@ class Client(object):
             before (int): A timestamp (in milliseconds), indicating from which point to retrieve threads
         :return: :class:`Thread` objects
         :rtype: list
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         if offset is not None:
             log.warning(
@@ -849,7 +889,9 @@ class Client(object):
 
         :return: List of unread thread ids
         :rtype: list
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         form = {
             "folders[0]": "inbox",
@@ -867,7 +909,9 @@ class Client(object):
 
         :return: List of unseen thread ids
         :rtype: list
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         j = self._payload_post("/mercury/unseen_thread_ids/", None)
 
@@ -881,7 +925,9 @@ class Client(object):
             image_id (str): The image you want to fethc
         :return: An url where you can download the original image
         :rtype: str
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         image_id = str(image_id)
         data = {"photo_id": str(image_id)}
@@ -900,7 +946,9 @@ class Client(object):
             thread_id: User/Group ID to get message info from. See :ref:`intro_threads`
         :return: :class:`Message` object
         :rtype: Message
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
         message_info = self._forcedFetch(thread_id, mid).get("message")
@@ -912,7 +960,9 @@ class Client(object):
         Args:
             poll_id: Poll ID to fetch from
         :rtype: list
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {"question_id": poll_id}
         j = self._payload_post("/ajax/mercury/get_poll_options", data)
@@ -925,7 +975,9 @@ class Client(object):
             plan_id: Plan ID to fetch from
         :return: :class:`Plan` object
         :rtype: Plan
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {"event_reminder_id": plan_id}
         j = self._payload_post("/ajax/eventreminder", data)
@@ -1122,7 +1174,9 @@ class Client(object):
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent message
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, thread_type)
         data = self._getSendData(
@@ -1158,7 +1212,9 @@ class Client(object):
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent message
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, thread_type)
         data = self._getSendData(thread_id=thread_id, thread_type=thread_type)
@@ -1180,7 +1236,9 @@ class Client(object):
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent message
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         quick_reply.is_response = True
         if isinstance(quick_reply, QuickReplyText):
@@ -1239,7 +1297,9 @@ class Client(object):
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent message
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         self._sendLocation(
             location=location,
@@ -1260,7 +1320,9 @@ class Client(object):
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent message
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         self._sendLocation(
             location=location,
@@ -1329,7 +1391,9 @@ class Client(object):
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent files
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         file_urls = require_list(file_urls)
         files = self._upload(get_files_from_urls(file_urls))
@@ -1348,7 +1412,9 @@ class Client(object):
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent files
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         file_paths = require_list(file_paths)
         with get_files_from_paths(file_paths) as x:
@@ -1368,7 +1434,9 @@ class Client(object):
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent files
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         clip_urls = require_list(clip_urls)
         files = self._upload(get_files_from_urls(clip_urls), voice_clip=True)
@@ -1387,7 +1455,9 @@ class Client(object):
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent files
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         clip_paths = require_list(clip_paths)
         with get_files_from_paths(clip_paths) as x:
@@ -1444,7 +1514,9 @@ class Client(object):
         Args:
             attachment_id: Attachment ID to forward
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
         data = {
@@ -1465,7 +1537,9 @@ class Client(object):
             message: The initial message
             user_ids: A list of users to create the group with.
         :return: ID of the new group
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = self._getSendData(message=self._oldMessage(message))
 
@@ -1488,7 +1562,9 @@ class Client(object):
         Args:
             user_ids (list): One or more user IDs to add
             thread_id: Group ID to add people to. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
         data = self._getSendData(thread_id=thread_id, thread_type=ThreadType.GROUP)
@@ -1516,7 +1592,9 @@ class Client(object):
         Args:
             user_id: User ID to remove
             thread_id: Group ID to remove people from. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
 
@@ -1541,7 +1619,9 @@ class Client(object):
         Args:
             admin_ids: One or more user IDs to set admin
             thread_id: Group ID to remove people from. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         self._adminStatus(admin_ids, True, thread_id)
 
@@ -1551,7 +1631,9 @@ class Client(object):
         Args:
             admin_ids: One or more user IDs to remove admin
             thread_id: Group ID to remove people from. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         self._adminStatus(admin_ids, False, thread_id)
 
@@ -1561,7 +1643,9 @@ class Client(object):
         Args:
             require_admin_approval: True or False
             thread_id: Group ID to remove people from. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
 
@@ -1591,7 +1675,9 @@ class Client(object):
         Args:
             user_ids: One or more user IDs to accept
             thread_id: Group ID to accept users to. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         self._usersApproval(user_ids, True, thread_id)
 
@@ -1601,7 +1687,9 @@ class Client(object):
         Args:
             user_ids: One or more user IDs to deny
             thread_id: Group ID to deny users from. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         self._usersApproval(user_ids, False, thread_id)
 
@@ -1611,7 +1699,9 @@ class Client(object):
         Args:
             image_id: ID of uploaded image
             thread_id: User/Group ID to change image. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
 
@@ -1626,7 +1716,9 @@ class Client(object):
         Args:
             image_url: URL of an image to upload and change
             thread_id: User/Group ID to change image. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         (image_id, mimetype), = self._upload(get_files_from_urls([image_url]))
         return self._changeGroupImage(image_id, thread_id)
@@ -1637,7 +1729,9 @@ class Client(object):
         Args:
             image_path: Path of an image to upload and change
             thread_id: User/Group ID to change image. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         with get_files_from_paths([image_path]) as files:
             (image_id, mimetype), = self._upload(files)
@@ -1654,7 +1748,9 @@ class Client(object):
             title: New group thread title
             thread_id: Group ID to change title of. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, thread_type)
 
@@ -1677,7 +1773,9 @@ class Client(object):
             user_id: User that will have their nickname changed
             thread_id: User/Group ID to change color of. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, thread_type)
 
@@ -1696,7 +1794,9 @@ class Client(object):
         Args:
             color (ThreadColor): New thread color
             thread_id: User/Group ID to change color of. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
 
@@ -1718,7 +1818,9 @@ class Client(object):
         Args:
             color: New thread emoji
             thread_id: User/Group ID to change emoji of. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
 
@@ -1733,7 +1835,9 @@ class Client(object):
         Args:
             message_id: :ref:`Message ID <intro_message_ids>` to react to
             reaction (MessageReaction): Reaction emoji to use, if None removes reaction
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {
             "action": "ADD_REACTION" if reaction else "REMOVE_REACTION",
@@ -1752,7 +1856,9 @@ class Client(object):
         Args:
             plan (Plan): Plan to set
             thread_id: User/Group ID to send plan to. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
 
@@ -1778,7 +1884,9 @@ class Client(object):
         Args:
             plan (Plan): Plan to edit
             new_plan: New plan
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {
             "event_reminder_id": plan.uid,
@@ -1796,7 +1904,9 @@ class Client(object):
 
         Args:
             plan: Plan to delete
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {"event_reminder_id": plan.uid, "delete": "true", "acontext": ACONTEXT}
         j = self._payload_post("/ajax/eventreminder/submit", data)
@@ -1807,7 +1917,9 @@ class Client(object):
         Args:
             plan: Plan to take part in or not
             take_part: Whether to take part in the plan
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {
             "event_reminder_id": plan.uid,
@@ -1827,7 +1939,9 @@ class Client(object):
         Args:
             poll (Poll): Poll to create
             thread_id: User/Group ID to create poll in. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
 
@@ -1857,7 +1971,9 @@ class Client(object):
             new_options: List of the new option names
             thread_id: User/Group ID to change status in. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {"question_id": poll_id}
 
@@ -1881,7 +1997,9 @@ class Client(object):
             status (TypingStatus): Specify the typing status
             thread_id: User/Group ID to change status in. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, thread_type)
 
@@ -1904,7 +2022,9 @@ class Client(object):
             thread_id: User/Group ID to which the message belongs. See :ref:`intro_threads`
             message_id: Message ID to set as delivered. See :ref:`intro_threads`
         :return: True
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {
             "message_ids[0]": message_id,
@@ -1931,7 +2051,9 @@ class Client(object):
 
         Args:
             thread_ids: User/Group IDs to set as read. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         self._readStatus(True, thread_ids)
 
@@ -1942,7 +2064,9 @@ class Client(object):
 
         Args:
             thread_ids: User/Group IDs to set as unread. See :ref:`intro_threads`
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         self._readStatus(False, thread_ids)
 
@@ -1968,7 +2092,9 @@ class Client(object):
         Args:
             friend_id: The ID of the friend that you want to remove
         :return: True
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {"uid": friend_id}
         j = self._payload_post("/ajax/profile/removefriendconfirm.php", data)
@@ -1980,7 +2106,9 @@ class Client(object):
         Args:
             user_id: The ID of the user that you want to block
         :return: True
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {"fbid": user_id}
         j = self._payload_post("/messaging/block_messages/?dpr=1", data)
@@ -1992,7 +2120,9 @@ class Client(object):
         Args:
             user_id: The ID of the user that you want to unblock
         :return: Whether the request was successful
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         data = {"fbid": user_id}
         j = self._payload_post("/messaging/unblock_messages/?dpr=1", data)
@@ -2005,7 +2135,9 @@ class Client(object):
             location (ThreadLocation): INBOX, PENDING, ARCHIVED or OTHER
             thread_ids: Thread IDs to move. See :ref:`intro_threads`
         :return: True
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_ids = require_list(thread_ids)
 
@@ -2037,7 +2169,9 @@ class Client(object):
         Args:
             thread_ids: Thread IDs to delete. See :ref:`intro_threads`
         :return: True
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_ids = require_list(thread_ids)
 
@@ -2060,7 +2194,9 @@ class Client(object):
         Args:
             thread_id: User/Group ID to mark as spam. See :ref:`intro_threads`
         :return: True
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
         j = self._payload_post("/ajax/mercury/mark_spam.php?dpr=1", {"id": thread_id})
@@ -2072,7 +2208,9 @@ class Client(object):
         Args:
             message_ids: Message IDs to delete
         :return: True
-        :raises: FBchatException if request failed
+
+        Raises:
+            FBchatException: If request failed
         """
         message_ids = require_list(message_ids)
         data = dict()
@@ -2834,7 +2972,8 @@ class Client(object):
     def startListening(self):
         """Start listening from an external event loop.
 
-        :raises: FBchatException if request failed
+        Raises:
+            FBchatException: If request failed
         """
         self.listening = True
 

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -37,11 +37,17 @@ class Client(object):
     """
 
     listening = False
-    """Whether the client is listening. Used when creating an external event loop to determine when to stop listening"""
+    """Whether the client is listening.
+
+    Used when creating an external event loop to determine when to stop listening.
+    """
 
     @property
     def ssl_verify(self):
-        """Verify ssl certificate, set to False to allow debugging with a proxy."""
+        """Verify ssl certificate.
+
+        Set to False to allow debugging with a proxy.
+        """
         # TODO: Deprecate this
         return self._state._session.verify
 
@@ -161,7 +167,8 @@ class Client(object):
             raise FBchatException("Missing payload: {}".format(j))
 
     def graphql_requests(self, *queries):
-        """
+        """Execute graphql queries.
+
         :param queries: Zero or more dictionaries
         :type queries: dict
 
@@ -177,8 +184,7 @@ class Client(object):
         return tuple(self._post("/api/graphqlbatch/", data, as_graphql=True))
 
     def graphql_request(self, query):
-        """
-        Shorthand for ``graphql_requests(query)[0]``
+        """Shorthand for ``graphql_requests(query)[0]``.
 
         :raises: FBchatException if request failed
         """
@@ -193,8 +199,7 @@ class Client(object):
     """
 
     def isLoggedIn(self):
-        """
-        Sends a request to Facebook to check the login status
+        """Send a request to Facebook to check the login status.
 
         :return: True if the client is still logged in
         :rtype: bool
@@ -202,7 +207,7 @@ class Client(object):
         return self._state.is_logged_in()
 
     def getSession(self):
-        """Retrieves session cookies
+        """Retrieve session cookies.
 
         :return: A dictionay containing session cookies
         :rtype: dict
@@ -210,7 +215,7 @@ class Client(object):
         return self._state.get_cookies()
 
     def setSession(self, session_cookies, user_agent=None):
-        """Loads session cookies
+        """Load session cookies.
 
         :param session_cookies: A dictionay containing session cookies
         :type session_cookies: dict
@@ -232,8 +237,9 @@ class Client(object):
         return True
 
     def login(self, email, password, max_tries=5, user_agent=None):
-        """
-        Uses ``email`` and ``password`` to login the user (If the user is already logged in, this will do a re-login)
+        """Login the user, using ``email`` and ``password``.
+
+        If the user is already logged in, this will do a re-login.
 
         :param email: Facebook ``email`` or ``id`` or ``phone number``
         :param password: Facebook account password
@@ -272,8 +278,7 @@ class Client(object):
                 break
 
     def logout(self):
-        """
-        Safely logs out the client
+        """Safely log out the client.
 
         :return: True if the action was successful
         :rtype: bool
@@ -293,8 +298,7 @@ class Client(object):
     """
 
     def _getThread(self, given_thread_id=None, given_thread_type=None):
-        """
-        Checks if thread ID is given, checks if default is set and returns correct values
+        """Check if thread ID is given and if default is set, and return correct values.
 
         :raises ValueError: If thread ID is not given and there is no default
         :return: Thread ID and thread type
@@ -309,8 +313,7 @@ class Client(object):
             return given_thread_id, given_thread_type
 
     def setDefaultThread(self, thread_id, thread_type):
-        """
-        Sets default thread to send messages to
+        """Set default thread to send messages to.
 
         :param thread_id: User/Group ID to default to. See :ref:`intro_threads`
         :param thread_type: See :ref:`intro_threads`
@@ -320,7 +323,7 @@ class Client(object):
         self._default_thread_type = thread_type
 
     def resetDefaultThread(self):
-        """Resets default thread"""
+        """Reset default thread."""
         self.setDefaultThread(None, None)
 
     """
@@ -336,8 +339,8 @@ class Client(object):
         return self.graphql_request(_graphql.from_doc_id("1768656253222505", params))
 
     def fetchThreads(self, thread_location, before=None, after=None, limit=None):
-        """
-        Get all threads in thread_location.
+        """Fetch all threads in ``thread_location``.
+
         Threads will be sorted from newest to oldest.
 
         :param thread_location: ThreadLocation: INBOX, PENDING, ARCHIVED or OTHER
@@ -389,8 +392,7 @@ class Client(object):
         return threads
 
     def fetchAllUsersFromThreads(self, threads):
-        """
-        Get all users involved in threads.
+        """Fetch all users involved in given threads.
 
         :param threads: Thread: List of threads to check for users
         :return: :class:`User` objects
@@ -415,8 +417,7 @@ class Client(object):
         return users
 
     def fetchAllUsers(self):
-        """
-        Gets all users the client is currently chatting with
+        """Fetch all users the client is currently chatting with.
 
         :return: :class:`User` objects
         :rtype: list
@@ -435,8 +436,7 @@ class Client(object):
         return users
 
     def searchForUsers(self, name, limit=10):
-        """
-        Find and get user by his/her name
+        """Find and get users by their name.
 
         :param name: Name of the user
         :param limit: The max. amount of users to fetch
@@ -450,8 +450,7 @@ class Client(object):
         return [User._from_graphql(node) for node in j[name]["users"]["nodes"]]
 
     def searchForPages(self, name, limit=10):
-        """
-        Find and get page by its name
+        """Find and get pages by their name.
 
         :param name: Name of the page
         :return: :class:`Page` objects, ordered by relevance
@@ -464,8 +463,7 @@ class Client(object):
         return [Page._from_graphql(node) for node in j[name]["pages"]["nodes"]]
 
     def searchForGroups(self, name, limit=10):
-        """
-        Find and get group thread by its name
+        """Find and get group threads by their name.
 
         :param name: Name of the group thread
         :param limit: The max. amount of groups to fetch
@@ -479,8 +477,7 @@ class Client(object):
         return [Group._from_graphql(node) for node in j["viewer"]["groups"]["nodes"]]
 
     def searchForThreads(self, name, limit=10):
-        """
-        Find and get a thread by its name
+        """Find and get threads by their name.
 
         :param name: Name of the thread
         :param limit: The max. amount of groups to fetch
@@ -511,8 +508,7 @@ class Client(object):
         return rtn
 
     def searchForMessageIDs(self, query, offset=0, limit=5, thread_id=None):
-        """
-        Find and get message IDs by query
+        """Find and get message IDs by query.
 
         :param query: Text to search for
         :param offset: Number of messages to skip
@@ -541,8 +537,7 @@ class Client(object):
             yield snippet["message_id"]
 
     def searchForMessages(self, query, offset=0, limit=5, thread_id=None):
-        """
-        Find and get :class:`Message` objects by query
+        """Find and get `Message` objects by query.
 
         .. warning::
             This method sends request for every found message ID.
@@ -564,8 +559,7 @@ class Client(object):
             yield self.fetchMessageInfo(mid, thread_id)
 
     def search(self, query, fetch_messages=False, thread_limit=5, message_limit=5):
-        """
-        Searches for messages in all threads
+        """Search for messages in all threads.
 
         :param query: Text to search for
         :param fetch_messages: Whether to fetch :class:`Message` objects or IDs only
@@ -632,8 +626,7 @@ class Client(object):
         return entries
 
     def fetchUserInfo(self, *user_ids):
-        """
-        Get users' info from IDs, unordered
+        """Fetch users' info from IDs, unordered.
 
         .. warning::
             Sends two requests, to fetch all available info!
@@ -654,8 +647,7 @@ class Client(object):
         return users
 
     def fetchPageInfo(self, *page_ids):
-        """
-        Get pages' info from IDs, unordered
+        """Fetch pages' info from IDs, unordered.
 
         .. warning::
             Sends two requests, to fetch all available info!
@@ -676,8 +668,7 @@ class Client(object):
         return pages
 
     def fetchGroupInfo(self, *group_ids):
-        """
-        Get groups' info from IDs, unordered
+        """Fetch groups' info from IDs, unordered.
 
         :param group_ids: One or more group ID(s) to query
         :return: :class:`Group` objects, labeled by their ID
@@ -695,8 +686,7 @@ class Client(object):
         return groups
 
     def fetchThreadInfo(self, *thread_ids):
-        """
-        Get threads' info from IDs, unordered
+        """Fetch threads' info from IDs, unordered.
 
         .. warning::
             Sends two requests if users or pages are present, to fetch all available info!
@@ -759,8 +749,7 @@ class Client(object):
         return rtn
 
     def fetchThreadMessages(self, thread_id=None, limit=20, before=None):
-        """
-        Get the last messages in a thread
+        """Fetch messages in a thread, ordered by most recent.
 
         :param thread_id: User/Group ID to get messages from. See :ref:`intro_threads`
         :param limit: Max. number of messages to retrieve
@@ -803,7 +792,7 @@ class Client(object):
     def fetchThreadList(
         self, offset=None, limit=20, thread_location=ThreadLocation.INBOX, before=None
     ):
-        """Get thread list of your facebook account
+        """Fetch the client's thread list.
 
         :param offset: Deprecated. Do not use!
         :param limit: Max. number of threads to retrieve. Capped at 20
@@ -853,8 +842,7 @@ class Client(object):
         return rtn
 
     def fetchUnread(self):
-        """
-        Get the unread thread list
+        """Fetch unread threads.
 
         :return: List of unread thread ids
         :rtype: list
@@ -872,8 +860,7 @@ class Client(object):
         return result["thread_fbids"] + result["other_user_fbids"]
 
     def fetchUnseen(self):
-        """
-        Get the unseen (new) thread list
+        """Fetch unseen / new threads.
 
         :return: List of unseen thread ids
         :rtype: list
@@ -885,7 +872,7 @@ class Client(object):
         return result["thread_fbids"] + result["other_user_fbids"]
 
     def fetchImageUrl(self, image_id):
-        """Fetches the url to the original image from an image attachment ID
+        """Fetch url to download the original image from an image attachment ID.
 
         :param image_id: The image you want to fethc
         :type image_id: str
@@ -903,8 +890,7 @@ class Client(object):
         return url
 
     def fetchMessageInfo(self, mid, thread_id=None):
-        """
-        Fetches :class:`Message` object from the message id
+        """Fetch `Message` object from the given message id.
 
         :param mid: Message ID to fetch from
         :param thread_id: User/Group ID to get message info from. See :ref:`intro_threads`
@@ -917,8 +903,7 @@ class Client(object):
         return Message._from_graphql(message_info)
 
     def fetchPollOptions(self, poll_id):
-        """
-        Fetches list of :class:`PollOption` objects from the poll id
+        """Fetch list of `PollOption` objects from the poll id.
 
         :param poll_id: Poll ID to fetch from
         :rtype: list
@@ -929,8 +914,7 @@ class Client(object):
         return [PollOption._from_graphql(m) for m in j]
 
     def fetchPlanInfo(self, plan_id):
-        """
-        Fetches a :class:`Plan` object from the plan id
+        """Fetch `Plan` object from the plan id.
 
         :param plan_id: Plan ID to fetch from
         :return: :class:`Plan` object
@@ -946,8 +930,7 @@ class Client(object):
         return j["viewer"]
 
     def getPhoneNumbers(self):
-        """
-        Fetches a list of user phone numbers.
+        """Fetch list of user's phone numbers.
 
         :return: List of phone numbers
         :rtype: list
@@ -958,8 +941,7 @@ class Client(object):
         ]
 
     def getEmails(self):
-        """
-        Fetches a list of user emails.
+        """Fetch list of user's emails.
 
         :return: List of emails
         :rtype: list
@@ -968,9 +950,9 @@ class Client(object):
         return [j["display_email"] for j in data["all_emails"]]
 
     def getUserActiveStatus(self, user_id):
-        """
-        Gets friend active status as an :class:`ActiveStatus` object.
-        Returns ``None`` if status isn't known.
+        """Fetch friend active status as an `ActiveStatus` object.
+
+        Return ``None`` if status isn't known.
 
         .. warning::
             Only works when listening.
@@ -982,8 +964,8 @@ class Client(object):
         return self._buddylist.get(str(user_id))
 
     def fetchThreadImages(self, thread_id=None):
-        """
-        Creates generator object for fetching images posted in thread.
+        """Fetch images posted in thread.
+
         :param thread_id: ID of the thread
         :return: :class:`ImageAttachment` or :class:`VideoAttachment`.
         :rtype: iterable
@@ -1029,7 +1011,7 @@ class Client(object):
         return message if isinstance(message, Message) else Message(text=message)
 
     def _getSendData(self, message=None, thread_id=None, thread_type=ThreadType.USER):
-        """Returns the data needed to send a request to `SendURL`"""
+        """Return the data needed to send a request to `SendURL`."""
         messageAndOTID = generateOfflineThreadingID()
         timestamp = now()
         data = {
@@ -1098,7 +1080,7 @@ class Client(object):
         return data
 
     def _doSendRequest(self, data, get_thread_id=False):
-        """Sends the data to `SendURL`, and returns the message ID or None on failure"""
+        """Send the data to `SendURL`, and returns the message ID or None on failure."""
         j = self._post("/messaging/send/", data)
 
         # update JS token if received in response
@@ -1125,8 +1107,7 @@ class Client(object):
             )
 
     def send(self, message, thread_id=None, thread_type=ThreadType.USER):
-        """
-        Sends a message to a thread
+        """Send message to a thread.
 
         :param message: Message to send
         :param thread_id: User/Group ID to send to. See :ref:`intro_threads`
@@ -1143,9 +1124,7 @@ class Client(object):
         return self._doSendRequest(data)
 
     def sendMessage(self, message, thread_id=None, thread_type=ThreadType.USER):
-        """
-        Deprecated. Use :func:`fbchat.Client.send` instead
-        """
+        """Deprecated. Use :func:`fbchat.Client.send` instead."""
         return self.send(
             Message(text=message), thread_id=thread_id, thread_type=thread_type
         )
@@ -1157,9 +1136,7 @@ class Client(object):
         thread_id=None,
         thread_type=ThreadType.USER,
     ):
-        """
-        Deprecated. Use :func:`fbchat.Client.send` instead
-        """
+        """Deprecated. Use :func:`fbchat.Client.send` instead."""
         return self.send(
             Message(text=emoji, emoji_size=size),
             thread_id=thread_id,
@@ -1167,8 +1144,7 @@ class Client(object):
         )
 
     def wave(self, wave_first=True, thread_id=None, thread_type=None):
-        """
-        Says hello with a wave to a thread!
+        """Wave hello to a thread.
 
         :param wave_first: Whether to wave first or wave back
         :param thread_id: User/Group ID to send to. See :ref:`intro_threads`
@@ -1189,8 +1165,7 @@ class Client(object):
         return self._doSendRequest(data)
 
     def quickReply(self, quick_reply, payload=None, thread_id=None, thread_type=None):
-        """
-        Replies to a chosen quick reply
+        """Reply to chosen quick reply.
 
         :param quick_reply: Quick reply to reply to
         :param payload: Optional answer to the quick reply
@@ -1228,8 +1203,7 @@ class Client(object):
             return self.send(Message(text=payload, quick_replies=[quick_reply]))
 
     def unsend(self, mid):
-        """
-        Unsends a message (removes for everyone)
+        """Unsend message by it's ID (removes it for everyone).
 
         :param mid: :ref:`Message ID <intro_message_ids>` of the message to unsend
         """
@@ -1250,8 +1224,7 @@ class Client(object):
         return self._doSendRequest(data)
 
     def sendLocation(self, location, message=None, thread_id=None, thread_type=None):
-        """
-        Sends a given location to a thread as the user's current location
+        """Send a given location to a thread as the user's current location.
 
         :param location: Location to send
         :param message: Additional message
@@ -1274,8 +1247,7 @@ class Client(object):
     def sendPinnedLocation(
         self, location, message=None, thread_id=None, thread_type=None
     ):
-        """
-        Sends a given location to a thread as a pinned location
+        """Send a given location to a thread as a pinned location.
 
         :param location: Location to send
         :param message: Additional message
@@ -1296,13 +1268,12 @@ class Client(object):
         )
 
     def _upload(self, files, voice_clip=False):
-        """
-        Uploads files to Facebook
+        """Upload files to Facebook.
 
-        `files` should be a list of files that requests can upload, see:
-        http://docs.python-requests.org/en/master/api/#requests.request
+        `files` should be a list of files that requests can upload, see
+        `requests.request <https://docs.python-requests.org/en/master/api/#requests.request>`_.
 
-        Returns a list of tuples with a file's ID and mimetype
+        Return a list of tuples with a file's ID and mimetype.
         """
         file_dict = {"upload_{}".format(i): f for i, f in enumerate(files)}
 
@@ -1325,10 +1296,9 @@ class Client(object):
     def _sendFiles(
         self, files, message=None, thread_id=None, thread_type=ThreadType.USER
     ):
-        """
-        Sends files from file IDs to a thread
+        """Send files from file IDs to a thread.
 
-        `files` should be a list of tuples, with a file's ID and mimetype
+        `files` should be a list of tuples, with a file's ID and mimetype.
         """
         thread_id, thread_type = self._getThread(thread_id, thread_type)
         data = self._getSendData(
@@ -1348,8 +1318,7 @@ class Client(object):
     def sendRemoteFiles(
         self, file_urls, message=None, thread_id=None, thread_type=ThreadType.USER
     ):
-        """
-        Sends files from URLs to a thread
+        """Send files from URLs to a thread.
 
         :param file_urls: URLs of files to upload and send
         :param message: Additional message
@@ -1368,8 +1337,7 @@ class Client(object):
     def sendLocalFiles(
         self, file_paths, message=None, thread_id=None, thread_type=ThreadType.USER
     ):
-        """
-        Sends local files to a thread
+        """Send local files to a thread.
 
         :param file_paths: Paths of files to upload and send
         :param message: Additional message
@@ -1389,8 +1357,7 @@ class Client(object):
     def sendRemoteVoiceClips(
         self, clip_urls, message=None, thread_id=None, thread_type=ThreadType.USER
     ):
-        """
-        Sends voice clips from URLs to a thread
+        """Send voice clips from URLs to a thread.
 
         :param clip_urls: URLs of clips to upload and send
         :param message: Additional message
@@ -1409,8 +1376,7 @@ class Client(object):
     def sendLocalVoiceClips(
         self, clip_paths, message=None, thread_id=None, thread_type=ThreadType.USER
     ):
-        """
-        Sends local voice clips to a thread
+        """Send local voice clips to a thread.
 
         :param clip_paths: Paths of clips to upload and send
         :param message: Additional message
@@ -1450,9 +1416,7 @@ class Client(object):
     def sendRemoteImage(
         self, image_url, message=None, thread_id=None, thread_type=ThreadType.USER
     ):
-        """
-        Deprecated. Use :func:`fbchat.Client.sendRemoteFiles` instead
-        """
+        """Deprecated. Use :func:`fbchat.Client.sendRemoteFiles` instead."""
         return self.sendRemoteFiles(
             file_urls=[image_url],
             message=message,
@@ -1463,9 +1427,7 @@ class Client(object):
     def sendLocalImage(
         self, image_path, message=None, thread_id=None, thread_type=ThreadType.USER
     ):
-        """
-        Deprecated. Use :func:`fbchat.Client.sendLocalFiles` instead
-        """
+        """Deprecated. Use :func:`fbchat.Client.sendLocalFiles` instead."""
         return self.sendLocalFiles(
             file_paths=[image_path],
             message=message,
@@ -1474,8 +1436,7 @@ class Client(object):
         )
 
     def forwardAttachment(self, attachment_id, thread_id=None):
-        """
-        Forwards an attachment
+        """Forward an attachment.
 
         :param attachment_id: Attachment ID to forward
         :param thread_id: User/Group ID to send to. See :ref:`intro_threads`
@@ -1494,8 +1455,7 @@ class Client(object):
             )
 
     def createGroup(self, message, user_ids):
-        """
-        Creates a group with the given ids
+        """Create a group with the given user ids.
 
         :param message: The initial message
         :param user_ids: A list of users to create the group with.
@@ -1518,8 +1478,7 @@ class Client(object):
         return thread_id
 
     def addUsersToGroup(self, user_ids, thread_id=None):
-        """
-        Adds users to a group.
+        """Add users to a group.
 
         :param user_ids: One or more user IDs to add
         :param thread_id: Group ID to add people to. See :ref:`intro_threads`
@@ -1547,8 +1506,7 @@ class Client(object):
         return self._doSendRequest(data)
 
     def removeUserFromGroup(self, user_id, thread_id=None):
-        """
-        Removes users from a group.
+        """Remove user from a group.
 
         :param user_id: User ID to remove
         :param thread_id: Group ID to remove people from. See :ref:`intro_threads`
@@ -1572,8 +1530,7 @@ class Client(object):
         j = self._payload_post("/messaging/save_admins/?dpr=1", data)
 
     def addGroupAdmins(self, admin_ids, thread_id=None):
-        """
-        Sets specifed users as group admins.
+        """Set specifed users as group admins.
 
         :param admin_ids: One or more user IDs to set admin
         :param thread_id: Group ID to remove people from. See :ref:`intro_threads`
@@ -1582,8 +1539,7 @@ class Client(object):
         self._adminStatus(admin_ids, True, thread_id)
 
     def removeGroupAdmins(self, admin_ids, thread_id=None):
-        """
-        Removes admin status from specifed users.
+        """Remove admin status from specifed users.
 
         :param admin_ids: One or more user IDs to remove admin
         :param thread_id: Group ID to remove people from. See :ref:`intro_threads`
@@ -1592,8 +1548,7 @@ class Client(object):
         self._adminStatus(admin_ids, False, thread_id)
 
     def changeGroupApprovalMode(self, require_admin_approval, thread_id=None):
-        """
-        Changes group's approval mode
+        """Change group's approval mode.
 
         :param require_admin_approval: True or False
         :param thread_id: Group ID to remove people from. See :ref:`intro_threads`
@@ -1622,8 +1577,7 @@ class Client(object):
         )
 
     def acceptUsersToGroup(self, user_ids, thread_id=None):
-        """
-        Accepts users to the group from the group's approval
+        """Accept users to the group from the group's approval.
 
         :param user_ids: One or more user IDs to accept
         :param thread_id: Group ID to accept users to. See :ref:`intro_threads`
@@ -1632,8 +1586,7 @@ class Client(object):
         self._usersApproval(user_ids, True, thread_id)
 
     def denyUsersFromGroup(self, user_ids, thread_id=None):
-        """
-        Denies users from the group's approval
+        """Deny users from joining the group.
 
         :param user_ids: One or more user IDs to deny
         :param thread_id: Group ID to deny users from. See :ref:`intro_threads`
@@ -1642,8 +1595,7 @@ class Client(object):
         self._usersApproval(user_ids, False, thread_id)
 
     def _changeGroupImage(self, image_id, thread_id=None):
-        """
-        Changes a thread image from an image id
+        """Change a thread image from an image id.
 
         :param image_id: ID of uploaded image
         :param thread_id: User/Group ID to change image. See :ref:`intro_threads`
@@ -1657,8 +1609,7 @@ class Client(object):
         return image_id
 
     def changeGroupImageRemote(self, image_url, thread_id=None):
-        """
-        Changes a thread image from a URL
+        """Change a thread image from a URL.
 
         :param image_url: URL of an image to upload and change
         :param thread_id: User/Group ID to change image. See :ref:`intro_threads`
@@ -1668,8 +1619,7 @@ class Client(object):
         return self._changeGroupImage(image_id, thread_id)
 
     def changeGroupImageLocal(self, image_path, thread_id=None):
-        """
-        Changes a thread image from a local path
+        """Change a thread image from a local path.
 
         :param image_path: Path of an image to upload and change
         :param thread_id: User/Group ID to change image. See :ref:`intro_threads`
@@ -1681,9 +1631,10 @@ class Client(object):
         return self._changeGroupImage(image_id, thread_id)
 
     def changeThreadTitle(self, title, thread_id=None, thread_type=ThreadType.USER):
-        """
-        Changes title of a thread.
-        If this is executed on a user thread, this will change the nickname of that user, effectively changing the title
+        """Change title of a thread.
+
+        If this is executed on a user thread, this will change the nickname of that
+        user, effectively changing the title.
 
         :param title: New group thread title
         :param thread_id: Group ID to change title of. See :ref:`intro_threads`
@@ -1705,8 +1656,7 @@ class Client(object):
     def changeNickname(
         self, nickname, user_id, thread_id=None, thread_type=ThreadType.USER
     ):
-        """
-        Changes the nickname of a user in a thread
+        """Change the nickname of a user in a thread.
 
         :param nickname: New nickname
         :param user_id: User that will have their nickname changed
@@ -1727,8 +1677,7 @@ class Client(object):
         )
 
     def changeThreadColor(self, color, thread_id=None):
-        """
-        Changes thread color
+        """Change thread color.
 
         :param color: New thread color
         :param thread_id: User/Group ID to change color of. See :ref:`intro_threads`
@@ -1746,10 +1695,11 @@ class Client(object):
         )
 
     def changeThreadEmoji(self, emoji, thread_id=None):
-        """
-        Changes thread color
+        """Change thread color.
 
-        Trivia: While changing the emoji, the Facebook web client actually sends multiple different requests, though only this one is required to make the change
+        .. note::
+            While changing the emoji, the Facebook web client actually sends multiple
+            different requests, though only this one is required to make the change.
 
         :param color: New thread emoji
         :param thread_id: User/Group ID to change emoji of. See :ref:`intro_threads`
@@ -1763,8 +1713,7 @@ class Client(object):
         )
 
     def reactToMessage(self, message_id, reaction):
-        """
-        Reacts to a message, or removes reaction
+        """React to a message, or removes reaction.
 
         :param message_id: :ref:`Message ID <intro_message_ids>` to react to
         :param reaction: Reaction emoji to use, if None removes reaction
@@ -1783,8 +1732,7 @@ class Client(object):
         handle_graphql_errors(j)
 
     def createPlan(self, plan, thread_id=None):
-        """
-        Sets a plan
+        """Set a plan.
 
         :param plan: Plan to set
         :param thread_id: User/Group ID to send plan to. See :ref:`intro_threads`
@@ -1810,8 +1758,7 @@ class Client(object):
             )
 
     def editPlan(self, plan, new_plan):
-        """
-        Edits a plan
+        """Edit a plan.
 
         :param plan: Plan to edit
         :param new_plan: New plan
@@ -1830,8 +1777,7 @@ class Client(object):
         j = self._payload_post("/ajax/eventreminder/submit", data)
 
     def deletePlan(self, plan):
-        """
-        Deletes a plan
+        """Delete a plan.
 
         :param plan: Plan to delete
         :raises: FBchatException if request failed
@@ -1840,8 +1786,7 @@ class Client(object):
         j = self._payload_post("/ajax/eventreminder/submit", data)
 
     def changePlanParticipation(self, plan, take_part=True):
-        """
-        Changes participation in a plan
+        """Change participation in a plan.
 
         :param plan: Plan to take part in or not
         :param take_part: Whether to take part in the plan
@@ -1855,15 +1800,12 @@ class Client(object):
         j = self._payload_post("/ajax/eventreminder/rsvp", data)
 
     def eventReminder(self, thread_id, time, title, location="", location_id=""):
-        """
-        Deprecated. Use :func:`fbchat.Client.createPlan` instead
-        """
+        """Deprecated. Use :func:`fbchat.Client.createPlan` instead."""
         plan = Plan(time=time, title=title, location=location, location_id=location_id)
         self.createPlan(plan=plan, thread_id=thread_id)
 
     def createPoll(self, poll, thread_id=None):
-        """
-        Creates poll in a group thread
+        """Create poll in a group thread.
 
         :param poll: Poll to create
         :param thread_id: User/Group ID to create poll in. See :ref:`intro_threads`
@@ -1890,8 +1832,7 @@ class Client(object):
             )
 
     def updatePollVote(self, poll_id, option_ids=[], new_options=[]):
-        """
-        Updates a poll vote
+        """Update a poll vote.
 
         :param poll_id: ID of the poll to update vote
         :param option_ids: List of the option IDs to vote
@@ -1917,8 +1858,7 @@ class Client(object):
             )
 
     def setTypingStatus(self, status, thread_id=None, thread_type=None):
-        """
-        Sets users typing status in a thread
+        """Set users typing status in a thread.
 
         :param status: Specify the typing status
         :param thread_id: User/Group ID to change status in. See :ref:`intro_threads`
@@ -1942,8 +1882,7 @@ class Client(object):
     """
 
     def markAsDelivered(self, thread_id, message_id):
-        """
-        Mark a message as delivered
+        """Mark a message as delivered.
 
         :param thread_id: User/Group ID to which the message belongs. See :ref:`intro_threads`
         :param message_id: Message ID to set as delivered. See :ref:`intro_threads`
@@ -1969,9 +1908,9 @@ class Client(object):
         j = self._payload_post("/ajax/mercury/change_read_status.php", data)
 
     def markAsRead(self, thread_ids=None):
-        """
-        Mark threads as read
-        All messages inside the threads will be marked as read
+        """Mark threads as read.
+
+        All messages inside the specified threads will be marked as read.
 
         :param thread_ids: User/Group IDs to set as read. See :ref:`intro_threads`
         :raises: FBchatException if request failed
@@ -1979,9 +1918,9 @@ class Client(object):
         self._readStatus(True, thread_ids)
 
     def markAsUnread(self, thread_ids=None):
-        """
-        Mark threads as unread
-        All messages inside the threads will be marked as unread
+        """Mark threads as unread.
+
+        All messages inside the specified threads will be marked as unread.
 
         :param thread_ids: User/Group IDs to set as unread. See :ref:`intro_threads`
         :raises: FBchatException if request failed
@@ -2005,8 +1944,7 @@ class Client(object):
         j = self._payload_post("/ajax/add_friend/action.php?dpr=1", data)
 
     def removeFriend(self, friend_id=None):
-        """
-        Removes a specifed friend from your friend list
+        """Remove a specifed friend from the client's friend list.
 
         :param friend_id: The ID of the friend that you want to remove
         :return: True
@@ -2017,8 +1955,7 @@ class Client(object):
         return True
 
     def blockUser(self, user_id):
-        """
-        Blocks messages from a specifed user
+        """Block messages from a specifed user.
 
         :param user_id: The ID of the user that you want to block
         :return: True
@@ -2029,8 +1966,7 @@ class Client(object):
         return True
 
     def unblockUser(self, user_id):
-        """
-        Unblocks messages from a blocked user
+        """Unblock a previously blocked user.
 
         :param user_id: The ID of the user that you want to unblock
         :return: Whether the request was successful
@@ -2041,8 +1977,7 @@ class Client(object):
         return True
 
     def moveThreads(self, location, thread_ids):
-        """
-        Moves threads to specifed location
+        """Move threads to specifed location.
 
         :param location: ThreadLocation: INBOX, PENDING, ARCHIVED or OTHER
         :param thread_ids: Thread IDs to move. See :ref:`intro_threads`
@@ -2074,8 +2009,7 @@ class Client(object):
         return True
 
     def deleteThreads(self, thread_ids):
-        """
-        Deletes threads
+        """Delete threads.
 
         :param thread_ids: Thread IDs to delete. See :ref:`intro_threads`
         :return: True
@@ -2097,8 +2031,7 @@ class Client(object):
         return True
 
     def markAsSpam(self, thread_id=None):
-        """
-        Mark a thread as spam and delete it
+        """Mark a thread as spam, and delete it.
 
         :param thread_id: User/Group ID to mark as spam. See :ref:`intro_threads`
         :return: True
@@ -2109,8 +2042,7 @@ class Client(object):
         return True
 
     def deleteMessages(self, message_ids):
-        """
-        Deletes specifed messages
+        """Delete specifed messages.
 
         :param message_ids: Message IDs to delete
         :return: True
@@ -2124,8 +2056,7 @@ class Client(object):
         return True
 
     def muteThread(self, mute_time=-1, thread_id=None):
-        """
-        Mutes thread
+        """Mute thread.
 
         :param mute_time: Mute time in seconds, leave blank to mute forever
         :param thread_id: User/Group ID to mute. See :ref:`intro_threads`
@@ -2135,16 +2066,14 @@ class Client(object):
         j = self._payload_post("/ajax/mercury/change_mute_thread.php?dpr=1", data)
 
     def unmuteThread(self, thread_id=None):
-        """
-        Unmutes thread
+        """Unmute thread.
 
         :param thread_id: User/Group ID to unmute. See :ref:`intro_threads`
         """
         return self.muteThread(0, thread_id)
 
     def muteThreadReactions(self, mute=True, thread_id=None):
-        """
-        Mutes thread reactions
+        """Mute thread reactions.
 
         :param mute: Boolean. True to mute, False to unmute
         :param thread_id: User/Group ID to mute. See :ref:`intro_threads`
@@ -2156,16 +2085,14 @@ class Client(object):
         )
 
     def unmuteThreadReactions(self, thread_id=None):
-        """
-        Unmutes thread reactions
+        """Unmute thread reactions.
 
         :param thread_id: User/Group ID to unmute. See :ref:`intro_threads`
         """
         return self.muteThreadReactions(False, thread_id)
 
     def muteThreadMentions(self, mute=True, thread_id=None):
-        """
-        Mutes thread mentions
+        """Mute thread mentions.
 
         :param mute: Boolean. True to mute, False to unmute
         :param thread_id: User/Group ID to mute. See :ref:`intro_threads`
@@ -2175,8 +2102,7 @@ class Client(object):
         j = self._payload_post("/ajax/mercury/change_mentions_mute_thread/?dpr=1", data)
 
     def unmuteThreadMentions(self, thread_id=None):
-        """
-        Unmutes thread mentions
+        """Unmute thread mentions.
 
         :param thread_id: User/Group ID to unmute. See :ref:`intro_threads`
         """
@@ -2205,7 +2131,7 @@ class Client(object):
         )
 
     def _pullMessage(self):
-        """Call pull api with seq value to get message data."""
+        """Call pull api to fetch message data."""
         data = {
             "seq": self._seq,
             "msgs_recv": 0,
@@ -2220,7 +2146,7 @@ class Client(object):
 
     def _parseDelta(self, m):
         def getThreadIdAndThreadType(msg_metadata):
-            """Returns a tuple consisting of thread ID and thread type"""
+            """Return a tuple consisting of thread ID and thread type."""
             id_thread = None
             type_thread = None
             if "threadFbId" in msg_metadata["threadKey"]:
@@ -2769,7 +2695,10 @@ class Client(object):
             self.onUnknownMesssageType(msg=m)
 
     def _parseMessage(self, content):
-        """Get message and author name from content. May contain multiple messages in the content."""
+        """Get message and author name from content.
+
+        May contain multiple messages in the content.
+        """
         self._seq = content.get("seq", "0")
 
         if "lb_info" in content:
@@ -2871,17 +2800,16 @@ class Client(object):
                 self.onMessageError(exception=e, msg=m)
 
     def startListening(self):
-        """
-        Start listening from an external event loop
+        """Start listening from an external event loop.
 
         :raises: FBchatException if request failed
         """
         self.listening = True
 
     def doOneListen(self, markAlive=None):
-        """
-        Does one cycle of the listening loop.
-        This method is useful if you want to control fbchat from an external event loop
+        """Do one cycle of the listening loop.
+
+        This method is useful if you want to control fbchat from an external event loop.
 
         .. warning::
             ``markAlive`` parameter is deprecated, use :func:`Client.setActiveStatus`
@@ -2919,13 +2847,12 @@ class Client(object):
         return True
 
     def stopListening(self):
-        """Cleans up the variables from startListening"""
+        """Clean up the variables from `Client.startListening`."""
         self.listening = False
         self._sticky, self._pool = (None, None)
 
     def listen(self, markAlive=None):
-        """
-        Initializes and runs the listening loop continually
+        """Initialize and runs the listening loop continually.
 
         :param markAlive: Whether this should ping the Facebook server each time the loop runs
         :type markAlive: bool
@@ -2942,8 +2869,7 @@ class Client(object):
         self.stopListening()
 
     def setActiveStatus(self, markAlive):
-        """
-        Changes client active status while listening
+        """Change active status while listening.
 
         :param markAlive: Whether to show if client is active
         :type markAlive: bool
@@ -2959,32 +2885,29 @@ class Client(object):
     """
 
     def onLoggingIn(self, email=None):
-        """
-        Called when the client is logging in
+        """Called when the client is logging in.
 
         :param email: The email of the client
         """
         log.info("Logging in {}...".format(email))
 
     def on2FACode(self):
-        """Called when a 2FA code is needed to progress"""
+        """Called when a 2FA code is needed to progress."""
         return input("Please enter your 2FA code --> ")
 
     def onLoggedIn(self, email=None):
-        """
-        Called when the client is successfully logged in
+        """Called when the client is successfully logged in.
 
         :param email: The email of the client
         """
         log.info("Login of {} successful.".format(email))
 
     def onListening(self):
-        """Called when the client is listening"""
+        """Called when the client is listening."""
         log.info("Listening...")
 
     def onListenError(self, exception=None):
-        """
-        Called when an error was encountered while listening
+        """Called when an error was encountered while listening.
 
         :param exception: The exception that was encountered
         :return: Whether the loop should keep running
@@ -3004,8 +2927,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody sends a message
+        """Called when the client is listening, and somebody sends a message.
 
         :param mid: The message ID
         :param author_id: The ID of the author
@@ -3032,8 +2954,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody changes a thread's color
+        """Called when the client is listening, and somebody changes a thread's color.
 
         :param mid: The action ID
         :param author_id: The ID of the person who changed the color
@@ -3063,8 +2984,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody changes a thread's emoji
+        """Called when the client is listening, and somebody changes a thread's emoji.
 
         :param mid: The action ID
         :param author_id: The ID of the person who changed the emoji
@@ -3093,8 +3013,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody changes the title of a thread
+        """Called when the client is listening, and somebody changes a thread's title.
 
         :param mid: The action ID
         :param author_id: The ID of the person who changed the title
@@ -3122,8 +3041,7 @@ class Client(object):
         ts=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody changes the image of a thread
+        """Called when the client is listening, and somebody changes a thread's image.
 
         :param mid: The action ID
         :param author_id: The ID of the person who changed the image
@@ -3148,8 +3066,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody changes the nickname of a person
+        """Called when the client is listening, and somebody changes a nickname.
 
         :param mid: The action ID
         :param author_id: The ID of the person who changed the nickname
@@ -3178,8 +3095,7 @@ class Client(object):
         ts=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody adds an admin to a group thread
+        """Called when the client is listening, and somebody adds an admin to a group.
 
         :param mid: The action ID
         :param added_id: The ID of the admin who got added
@@ -3200,8 +3116,7 @@ class Client(object):
         ts=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody removes an admin from a group thread
+        """Called when the client is listening, and somebody is removed as an admin in a group.
 
         :param mid: The action ID
         :param removed_id: The ID of the admin who got removed
@@ -3222,8 +3137,7 @@ class Client(object):
         ts=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody changes approval mode in a group thread
+        """Called when the client is listening, and somebody changes approval mode in a group.
 
         :param mid: The action ID
         :param approval_mode: True if approval mode is activated
@@ -3247,8 +3161,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody marks a message as seen
+        """Called when the client is listening, and somebody marks a message as seen.
 
         :param seen_by: The ID of the person who marked the message as seen
         :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
@@ -3275,8 +3188,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody marks messages as delivered
+        """Called when the client is listening, and somebody marks messages as delivered.
 
         :param msg_ids: The messages that are marked as delivered
         :param delivered_for: The person that marked the messages as delivered
@@ -3296,8 +3208,7 @@ class Client(object):
     def onMarkedSeen(
         self, threads=None, seen_ts=None, ts=None, metadata=None, msg=None
     ):
-        """
-        Called when the client is listening, and the client has successfully marked threads as seen
+        """Called when the client is listening, and the client has successfully marked threads as seen.
 
         :param threads: The threads that were marked
         :param author_id: The ID of the person who changed the emoji
@@ -3322,8 +3233,7 @@ class Client(object):
         ts=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and someone unsends (deletes for everyone) a message
+        """Called when the client is listening, and someone unsends (deletes for everyone) a message.
 
         :param mid: ID of the unsent message
         :param author_id: The ID of the person who unsent the message
@@ -3348,8 +3258,7 @@ class Client(object):
         ts=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody adds people to a group thread
+        """Called when the client is listening, and somebody adds people to a group thread.
 
         :param mid: The action ID
         :param added_ids: The IDs of the people who got added
@@ -3371,8 +3280,7 @@ class Client(object):
         ts=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody removes a person from a group thread
+        """Called when the client is listening, and somebody removes a person from a group thread.
 
         :param mid: The action ID
         :param removed_id: The ID of the person who got removed
@@ -3384,8 +3292,7 @@ class Client(object):
         log.info("{} removed: {} in {}".format(author_id, removed_id, thread_id))
 
     def onFriendRequest(self, from_id=None, msg=None):
-        """
-        Called when the client is listening, and somebody sends a friend request
+        """Called when the client is listening, and somebody sends a friend request.
 
         :param from_id: The ID of the person that sent the request
         :param msg: A full set of the data recieved
@@ -3407,8 +3314,7 @@ class Client(object):
     def onTyping(
         self, author_id=None, status=None, thread_id=None, thread_type=None, msg=None
     ):
-        """
-        Called when the client is listening, and somebody starts or stops typing into a chat
+        """Called when the client is listening, and somebody starts or stops typing into a chat.
 
         :param author_id: The ID of the person who sent the action
         :param status: The typing status
@@ -3434,8 +3340,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody plays a game
+        """Called when the client is listening, and somebody plays a game.
 
         :param mid: The action ID
         :param author_id: The ID of the person who played the game
@@ -3466,8 +3371,7 @@ class Client(object):
         ts=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody reacts to a message
+        """Called when the client is listening, and somebody reacts to a message.
 
         :param mid: Message ID, that user reacted to
         :param reaction: Reaction
@@ -3495,8 +3399,7 @@ class Client(object):
         ts=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody removes reaction from a message
+        """Called when the client is listening, and somebody removes reaction from a message.
 
         :param mid: Message ID, that user reacted to
         :param author_id: The ID of the person who removed reaction
@@ -3515,8 +3418,7 @@ class Client(object):
     def onBlock(
         self, author_id=None, thread_id=None, thread_type=None, ts=None, msg=None
     ):
-        """
-        Called when the client is listening, and somebody blocks client
+        """Called when the client is listening, and somebody blocks client.
 
         :param author_id: The ID of the person who blocked
         :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
@@ -3532,8 +3434,7 @@ class Client(object):
     def onUnblock(
         self, author_id=None, thread_id=None, thread_type=None, ts=None, msg=None
     ):
-        """
-        Called when the client is listening, and somebody blocks client
+        """Called when the client is listening, and somebody blocks client.
 
         :param author_id: The ID of the person who unblocked
         :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
@@ -3556,8 +3457,7 @@ class Client(object):
         ts=None,
         msg=None,
     ):
-        """
-        Called when the client is listening and somebody sends live location info
+        """Called when the client is listening and somebody sends live location info.
 
         :param mid: The action ID
         :param location: Sent location info
@@ -3586,11 +3486,10 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        .. todo::
-            Make this work with private calls
+        """Called when the client is listening, and somebody starts a call in a group.
 
-        Called when the client is listening, and somebody starts a call in a group
+        .. todo::
+            Make this work with private calls.
 
         :param mid: The action ID
         :param caller_id: The ID of the person who started the call
@@ -3618,11 +3517,10 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        .. todo::
-            Make this work with private calls
+        """Called when the client is listening, and somebody ends a call in a group.
 
-        Called when the client is listening, and somebody ends a call in a group
+        .. todo::
+            Make this work with private calls.
 
         :param mid: The action ID
         :param caller_id: The ID of the person who ended the call
@@ -3650,8 +3548,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody joins a group call
+        """Called when the client is listening, and somebody joins a group call.
 
         :param mid: The action ID
         :param joined_id: The ID of the person who joined the call
@@ -3678,8 +3575,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody creates a group poll
+        """Called when the client is listening, and somebody creates a group poll.
 
         :param mid: The action ID
         :param poll: Created poll
@@ -3711,8 +3607,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody votes in a group poll
+        """Called when the client is listening, and somebody votes in a group poll.
 
         :param mid: The action ID
         :param poll: Poll, that user voted in
@@ -3742,8 +3637,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody creates a plan
+        """Called when the client is listening, and somebody creates a plan.
 
         :param mid: The action ID
         :param plan: Created plan
@@ -3772,8 +3666,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and a plan ends
+        """Called when the client is listening, and a plan ends.
 
         :param mid: The action ID
         :param plan: Ended plan
@@ -3800,8 +3693,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody edits a plan
+        """Called when the client is listening, and somebody edits a plan.
 
         :param mid: The action ID
         :param plan: Edited plan
@@ -3831,8 +3723,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody deletes a plan
+        """Called when the client is listening, and somebody deletes a plan.
 
         :param mid: The action ID
         :param plan: Deleted plan
@@ -3863,8 +3754,7 @@ class Client(object):
         metadata=None,
         msg=None,
     ):
-        """
-        Called when the client is listening, and somebody takes part in a plan or not
+        """Called when the client is listening, and somebody takes part in a plan or not.
 
         :param mid: The action ID
         :param plan: Plan
@@ -3893,8 +3783,7 @@ class Client(object):
             )
 
     def onQprimer(self, ts=None, msg=None):
-        """
-        Called when the client just started listening
+        """Called when the client just started listening.
 
         :param ts: A timestamp of the action
         :param msg: A full set of the data recieved
@@ -3902,8 +3791,7 @@ class Client(object):
         pass
 
     def onChatTimestamp(self, buddylist=None, msg=None):
-        """
-        Called when the client receives chat online presence update
+        """Called when the client receives chat online presence update.
 
         :param buddylist: A list of dicts with friend id and last seen timestamp
         :param msg: A full set of the data recieved
@@ -3911,8 +3799,7 @@ class Client(object):
         log.debug("Chat Timestamps received: {}".format(buddylist))
 
     def onBuddylistOverlay(self, statuses=None, msg=None):
-        """
-        Called when the client is listening and client receives information about friend active status
+        """Called when the client is listening and client receives information about friend active status.
 
         :param statuses: Dictionary with user IDs as keys and :class:`ActiveStatus` as values
         :param msg: A full set of the data recieved
@@ -3921,16 +3808,14 @@ class Client(object):
         log.debug("Buddylist overlay received: {}".format(statuses))
 
     def onUnknownMesssageType(self, msg=None):
-        """
-        Called when the client is listening, and some unknown data was recieved
+        """Called when the client is listening, and some unknown data was recieved.
 
         :param msg: A full set of the data recieved
         """
         log.debug("Unknown message received: {}".format(msg))
 
     def onMessageError(self, exception=None, msg=None):
-        """
-        Called when an error was encountered while parsing recieved data
+        """Called when an error was encountered while parsing recieved data.
 
         :param exception: The exception that was encountered
         :param msg: A full set of the data recieved

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -74,12 +74,13 @@ class Client(object):
     ):
         """Initialize and log in the client.
 
-        :param email: Facebook ``email``, ``id`` or ``phone number``
-        :param password: Facebook account password
-        :param user_agent: Custom user agent to use when sending requests. If `None`, user agent will be chosen from a premade list
-        :param max_tries: Maximum number of times to try logging in
-        :param session_cookies: Cookies from a previous session (Will default to login if these are invalid)
-        :param logging_level: Configures the `logging level <https://docs.python.org/3/library/logging.html#logging-levels>`_. Defaults to ``logging.INFO``
+        Args:
+            email: Facebook ``email``, ``id`` or ``phone number``
+            password: Facebook account password
+            user_agent: Custom user agent to use when sending requests. If `None`, user agent will be chosen from a premade list
+            max_tries: Maximum number of times to try logging in
+            session_cookies: Cookies from a previous session (Will default to login if these are invalid)
+            logging_level: Configures the `logging level <https://docs.python.org/3/library/logging.html#logging-levels>`_. Defaults to ``logging.INFO``
         :type max_tries: int
         :type session_cookies: dict
         :type logging_level: int
@@ -169,7 +170,8 @@ class Client(object):
     def graphql_requests(self, *queries):
         """Execute graphql queries.
 
-        :param queries: Zero or more dictionaries
+        Args:
+            queries: Zero or more dictionaries
         :type queries: dict
 
         :raises: FBchatException if request failed
@@ -217,7 +219,8 @@ class Client(object):
     def setSession(self, session_cookies, user_agent=None):
         """Load session cookies.
 
-        :param session_cookies: A dictionay containing session cookies
+        Args:
+            session_cookies: A dictionay containing session cookies
         :type session_cookies: dict
         :return: False if ``session_cookies`` does not contain proper cookies
         :rtype: bool
@@ -241,9 +244,10 @@ class Client(object):
 
         If the user is already logged in, this will do a re-login.
 
-        :param email: Facebook ``email`` or ``id`` or ``phone number``
-        :param password: Facebook account password
-        :param max_tries: Maximum number of times to try logging in
+        Args:
+            email: Facebook ``email`` or ``id`` or ``phone number``
+            password: Facebook account password
+            max_tries: Maximum number of times to try logging in
         :type max_tries: int
         :raises: FBchatException on failed login
         """
@@ -315,8 +319,9 @@ class Client(object):
     def setDefaultThread(self, thread_id, thread_type):
         """Set default thread to send messages to.
 
-        :param thread_id: User/Group ID to default to. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            thread_id: User/Group ID to default to. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type thread_type: ThreadType
         """
         self._default_thread_id = thread_id
@@ -343,10 +348,11 @@ class Client(object):
 
         Threads will be sorted from newest to oldest.
 
-        :param thread_location: ThreadLocation: INBOX, PENDING, ARCHIVED or OTHER
-        :param before: Fetch only thread before this epoch (in ms) (default all threads)
-        :param after: Fetch only thread after this epoch (in ms) (default all threads)
-        :param limit: The max. amount of threads to fetch (default all threads)
+        Args:
+            thread_location (ThreadLocation): INBOX, PENDING, ARCHIVED or OTHER
+            before: Fetch only thread before this epoch (in ms) (default all threads)
+            after: Fetch only thread after this epoch (in ms) (default all threads)
+            limit: The max. amount of threads to fetch (default all threads)
         :return: :class:`Thread` objects
         :rtype: list
         :raises: FBchatException if request failed
@@ -394,7 +400,8 @@ class Client(object):
     def fetchAllUsersFromThreads(self, threads):
         """Fetch all users involved in given threads.
 
-        :param threads: Thread: List of threads to check for users
+        Args:
+            threads: Thread: List of threads to check for users
         :return: :class:`User` objects
         :rtype: list
         :raises: FBchatException if request failed
@@ -438,8 +445,9 @@ class Client(object):
     def searchForUsers(self, name, limit=10):
         """Find and get users by their name.
 
-        :param name: Name of the user
-        :param limit: The max. amount of users to fetch
+        Args:
+            name: Name of the user
+            limit: The max. amount of users to fetch
         :return: :class:`User` objects, ordered by relevance
         :rtype: list
         :raises: FBchatException if request failed
@@ -452,7 +460,8 @@ class Client(object):
     def searchForPages(self, name, limit=10):
         """Find and get pages by their name.
 
-        :param name: Name of the page
+        Args:
+            name: Name of the page
         :return: :class:`Page` objects, ordered by relevance
         :rtype: list
         :raises: FBchatException if request failed
@@ -465,8 +474,9 @@ class Client(object):
     def searchForGroups(self, name, limit=10):
         """Find and get group threads by their name.
 
-        :param name: Name of the group thread
-        :param limit: The max. amount of groups to fetch
+        Args:
+            name: Name of the group thread
+            limit: The max. amount of groups to fetch
         :return: :class:`Group` objects, ordered by relevance
         :rtype: list
         :raises: FBchatException if request failed
@@ -479,8 +489,9 @@ class Client(object):
     def searchForThreads(self, name, limit=10):
         """Find and get threads by their name.
 
-        :param name: Name of the thread
-        :param limit: The max. amount of groups to fetch
+        Args:
+            name: Name of the thread
+            limit: The max. amount of groups to fetch
         :return: :class:`User`, :class:`Group` and :class:`Page` objects, ordered by relevance
         :rtype: list
         :raises: FBchatException if request failed
@@ -510,10 +521,11 @@ class Client(object):
     def searchForMessageIDs(self, query, offset=0, limit=5, thread_id=None):
         """Find and get message IDs by query.
 
-        :param query: Text to search for
-        :param offset: Number of messages to skip
-        :param limit: Max. number of messages to retrieve
-        :param thread_id: User/Group ID to search in. See :ref:`intro_threads`
+        Args:
+            query: Text to search for
+            offset: Number of messages to skip
+            limit: Max. number of messages to retrieve
+            thread_id: User/Group ID to search in. See :ref:`intro_threads`
         :type offset: int
         :type limit: int
         :return: Found Message IDs
@@ -542,10 +554,11 @@ class Client(object):
         .. warning::
             This method sends request for every found message ID.
 
-        :param query: Text to search for
-        :param offset: Number of messages to skip
-        :param limit: Max. number of messages to retrieve
-        :param thread_id: User/Group ID to search in. See :ref:`intro_threads`
+        Args:
+            query: Text to search for
+            offset: Number of messages to skip
+            limit: Max. number of messages to retrieve
+            thread_id: User/Group ID to search in. See :ref:`intro_threads`
         :type offset: int
         :type limit: int
         :return: Found :class:`Message` objects
@@ -561,10 +574,11 @@ class Client(object):
     def search(self, query, fetch_messages=False, thread_limit=5, message_limit=5):
         """Search for messages in all threads.
 
-        :param query: Text to search for
-        :param fetch_messages: Whether to fetch :class:`Message` objects or IDs only
-        :param thread_limit: Max. number of threads to retrieve
-        :param message_limit: Max. number of messages to retrieve
+        Args:
+            query: Text to search for
+            fetch_messages: Whether to fetch :class:`Message` objects or IDs only
+            thread_limit: Max. number of threads to retrieve
+            message_limit: Max. number of messages to retrieve
         :type thread_limit: int
         :type message_limit: int
         :return: Dictionary with thread IDs as keys and iterables to get messages as values
@@ -631,7 +645,8 @@ class Client(object):
         .. warning::
             Sends two requests, to fetch all available info!
 
-        :param user_ids: One or more user ID(s) to query
+        Args:
+            user_ids: One or more user ID(s) to query
         :return: :class:`User` objects, labeled by their ID
         :rtype: dict
         :raises: FBchatException if request failed
@@ -652,7 +667,8 @@ class Client(object):
         .. warning::
             Sends two requests, to fetch all available info!
 
-        :param page_ids: One or more page ID(s) to query
+        Args:
+            page_ids: One or more page ID(s) to query
         :return: :class:`Page` objects, labeled by their ID
         :rtype: dict
         :raises: FBchatException if request failed
@@ -670,7 +686,8 @@ class Client(object):
     def fetchGroupInfo(self, *group_ids):
         """Fetch groups' info from IDs, unordered.
 
-        :param group_ids: One or more group ID(s) to query
+        Args:
+            group_ids: One or more group ID(s) to query
         :return: :class:`Group` objects, labeled by their ID
         :rtype: dict
         :raises: FBchatException if request failed
@@ -691,7 +708,8 @@ class Client(object):
         .. warning::
             Sends two requests if users or pages are present, to fetch all available info!
 
-        :param thread_ids: One or more thread ID(s) to query
+        Args:
+            thread_ids: One or more thread ID(s) to query
         :return: :class:`Thread` objects, labeled by their ID
         :rtype: dict
         :raises: FBchatException if request failed
@@ -751,9 +769,10 @@ class Client(object):
     def fetchThreadMessages(self, thread_id=None, limit=20, before=None):
         """Fetch messages in a thread, ordered by most recent.
 
-        :param thread_id: User/Group ID to get messages from. See :ref:`intro_threads`
-        :param limit: Max. number of messages to retrieve
-        :param before: A timestamp, indicating from which point to retrieve messages
+        Args:
+            thread_id: User/Group ID to get messages from. See :ref:`intro_threads`
+            limit: Max. number of messages to retrieve
+            before: A timestamp, indicating from which point to retrieve messages
         :type limit: int
         :type before: int
         :return: :class:`Message` objects
@@ -794,10 +813,11 @@ class Client(object):
     ):
         """Fetch the client's thread list.
 
-        :param offset: Deprecated. Do not use!
-        :param limit: Max. number of threads to retrieve. Capped at 20
-        :param thread_location: ThreadLocation: INBOX, PENDING, ARCHIVED or OTHER
-        :param before: A timestamp (in milliseconds), indicating from which point to retrieve threads
+        Args:
+            offset: Deprecated. Do not use!
+            limit: Max. number of threads to retrieve. Capped at 20
+            thread_location (ThreadLocation): INBOX, PENDING, ARCHIVED or OTHER
+            before: A timestamp (in milliseconds), indicating from which point to retrieve threads
         :type limit: int
         :type before: int
         :return: :class:`Thread` objects
@@ -874,7 +894,8 @@ class Client(object):
     def fetchImageUrl(self, image_id):
         """Fetch url to download the original image from an image attachment ID.
 
-        :param image_id: The image you want to fethc
+        Args:
+            image_id: The image you want to fethc
         :type image_id: str
         :return: An url where you can download the original image
         :rtype: str
@@ -892,8 +913,9 @@ class Client(object):
     def fetchMessageInfo(self, mid, thread_id=None):
         """Fetch `Message` object from the given message id.
 
-        :param mid: Message ID to fetch from
-        :param thread_id: User/Group ID to get message info from. See :ref:`intro_threads`
+        Args:
+            mid: Message ID to fetch from
+            thread_id: User/Group ID to get message info from. See :ref:`intro_threads`
         :return: :class:`Message` object
         :rtype: Message
         :raises: FBchatException if request failed
@@ -905,7 +927,8 @@ class Client(object):
     def fetchPollOptions(self, poll_id):
         """Fetch list of `PollOption` objects from the poll id.
 
-        :param poll_id: Poll ID to fetch from
+        Args:
+            poll_id: Poll ID to fetch from
         :rtype: list
         :raises: FBchatException if request failed
         """
@@ -916,7 +939,8 @@ class Client(object):
     def fetchPlanInfo(self, plan_id):
         """Fetch `Plan` object from the plan id.
 
-        :param plan_id: Plan ID to fetch from
+        Args:
+            plan_id: Plan ID to fetch from
         :return: :class:`Plan` object
         :rtype: Plan
         :raises: FBchatException if request failed
@@ -957,7 +981,8 @@ class Client(object):
         .. warning::
             Only works when listening.
 
-        :param user_id: ID of the user
+        Args:
+            user_id: ID of the user
         :return: Given user active status
         :rtype: ActiveStatus
         """
@@ -966,7 +991,8 @@ class Client(object):
     def fetchThreadImages(self, thread_id=None):
         """Fetch images posted in thread.
 
-        :param thread_id: ID of the thread
+        Args:
+            thread_id: ID of the thread
         :return: :class:`ImageAttachment` or :class:`VideoAttachment`.
         :rtype: iterable
         """
@@ -1109,9 +1135,10 @@ class Client(object):
     def send(self, message, thread_id=None, thread_type=ThreadType.USER):
         """Send message to a thread.
 
-        :param message: Message to send
-        :param thread_id: User/Group ID to send to. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            message: Message to send
+            thread_id: User/Group ID to send to. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type message: Message
         :type thread_type: ThreadType
         :return: :ref:`Message ID <intro_message_ids>` of the sent message
@@ -1146,9 +1173,10 @@ class Client(object):
     def wave(self, wave_first=True, thread_id=None, thread_type=None):
         """Wave hello to a thread.
 
-        :param wave_first: Whether to wave first or wave back
-        :param thread_id: User/Group ID to send to. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            wave_first: Whether to wave first or wave back
+            thread_id: User/Group ID to send to. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type thread_type: ThreadType
         :return: :ref:`Message ID <intro_message_ids>` of the sent message
         :raises: FBchatException if request failed
@@ -1167,10 +1195,11 @@ class Client(object):
     def quickReply(self, quick_reply, payload=None, thread_id=None, thread_type=None):
         """Reply to chosen quick reply.
 
-        :param quick_reply: Quick reply to reply to
-        :param payload: Optional answer to the quick reply
-        :param thread_id: User/Group ID to send to. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            quick_reply: Quick reply to reply to
+            payload: Optional answer to the quick reply
+            thread_id: User/Group ID to send to. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type quick_reply: QuickReply
         :type thread_type: ThreadType
         :return: :ref:`Message ID <intro_message_ids>` of the sent message
@@ -1205,7 +1234,8 @@ class Client(object):
     def unsend(self, mid):
         """Unsend message by it's ID (removes it for everyone).
 
-        :param mid: :ref:`Message ID <intro_message_ids>` of the message to unsend
+        Args:
+            mid: :ref:`Message ID <intro_message_ids>` of the message to unsend
         """
         data = {"message_id": mid}
         j = self._payload_post("/messaging/unsend_message/?dpr=1", data)
@@ -1226,10 +1256,11 @@ class Client(object):
     def sendLocation(self, location, message=None, thread_id=None, thread_type=None):
         """Send a given location to a thread as the user's current location.
 
-        :param location: Location to send
-        :param message: Additional message
-        :param thread_id: User/Group ID to send to. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            location: Location to send
+            message: Additional message
+            thread_id: User/Group ID to send to. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type location: LocationAttachment
         :type message: Message
         :type thread_type: ThreadType
@@ -1249,10 +1280,11 @@ class Client(object):
     ):
         """Send a given location to a thread as a pinned location.
 
-        :param location: Location to send
-        :param message: Additional message
-        :param thread_id: User/Group ID to send to. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            location: Location to send
+            message: Additional message
+            thread_id: User/Group ID to send to. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type location: LocationAttachment
         :type message: Message
         :type thread_type: ThreadType
@@ -1320,10 +1352,11 @@ class Client(object):
     ):
         """Send files from URLs to a thread.
 
-        :param file_urls: URLs of files to upload and send
-        :param message: Additional message
-        :param thread_id: User/Group ID to send to. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            file_urls: URLs of files to upload and send
+            message: Additional message
+            thread_id: User/Group ID to send to. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type thread_type: ThreadType
         :return: :ref:`Message ID <intro_message_ids>` of the sent files
         :raises: FBchatException if request failed
@@ -1339,10 +1372,11 @@ class Client(object):
     ):
         """Send local files to a thread.
 
-        :param file_paths: Paths of files to upload and send
-        :param message: Additional message
-        :param thread_id: User/Group ID to send to. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            file_paths: Paths of files to upload and send
+            message: Additional message
+            thread_id: User/Group ID to send to. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type thread_type: ThreadType
         :return: :ref:`Message ID <intro_message_ids>` of the sent files
         :raises: FBchatException if request failed
@@ -1359,10 +1393,11 @@ class Client(object):
     ):
         """Send voice clips from URLs to a thread.
 
-        :param clip_urls: URLs of clips to upload and send
-        :param message: Additional message
-        :param thread_id: User/Group ID to send to. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            clip_urls: URLs of clips to upload and send
+            message: Additional message
+            thread_id: User/Group ID to send to. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type thread_type: ThreadType
         :return: :ref:`Message ID <intro_message_ids>` of the sent files
         :raises: FBchatException if request failed
@@ -1378,10 +1413,11 @@ class Client(object):
     ):
         """Send local voice clips to a thread.
 
-        :param clip_paths: Paths of clips to upload and send
-        :param message: Additional message
-        :param thread_id: User/Group ID to send to. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            clip_paths: Paths of clips to upload and send
+            message: Additional message
+            thread_id: User/Group ID to send to. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type thread_type: ThreadType
         :return: :ref:`Message ID <intro_message_ids>` of the sent files
         :raises: FBchatException if request failed
@@ -1438,8 +1474,9 @@ class Client(object):
     def forwardAttachment(self, attachment_id, thread_id=None):
         """Forward an attachment.
 
-        :param attachment_id: Attachment ID to forward
-        :param thread_id: User/Group ID to send to. See :ref:`intro_threads`
+        Args:
+            attachment_id: Attachment ID to forward
+            thread_id: User/Group ID to send to. See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
@@ -1457,8 +1494,9 @@ class Client(object):
     def createGroup(self, message, user_ids):
         """Create a group with the given user ids.
 
-        :param message: The initial message
-        :param user_ids: A list of users to create the group with.
+        Args:
+            message: The initial message
+            user_ids: A list of users to create the group with.
         :return: ID of the new group
         :raises: FBchatException if request failed
         """
@@ -1480,8 +1518,9 @@ class Client(object):
     def addUsersToGroup(self, user_ids, thread_id=None):
         """Add users to a group.
 
-        :param user_ids: One or more user IDs to add
-        :param thread_id: Group ID to add people to. See :ref:`intro_threads`
+        Args:
+            user_ids: One or more user IDs to add
+            thread_id: Group ID to add people to. See :ref:`intro_threads`
         :type user_ids: list
         :raises: FBchatException if request failed
         """
@@ -1508,8 +1547,9 @@ class Client(object):
     def removeUserFromGroup(self, user_id, thread_id=None):
         """Remove user from a group.
 
-        :param user_id: User ID to remove
-        :param thread_id: Group ID to remove people from. See :ref:`intro_threads`
+        Args:
+            user_id: User ID to remove
+            thread_id: Group ID to remove people from. See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
@@ -1532,8 +1572,9 @@ class Client(object):
     def addGroupAdmins(self, admin_ids, thread_id=None):
         """Set specifed users as group admins.
 
-        :param admin_ids: One or more user IDs to set admin
-        :param thread_id: Group ID to remove people from. See :ref:`intro_threads`
+        Args:
+            admin_ids: One or more user IDs to set admin
+            thread_id: Group ID to remove people from. See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         self._adminStatus(admin_ids, True, thread_id)
@@ -1541,8 +1582,9 @@ class Client(object):
     def removeGroupAdmins(self, admin_ids, thread_id=None):
         """Remove admin status from specifed users.
 
-        :param admin_ids: One or more user IDs to remove admin
-        :param thread_id: Group ID to remove people from. See :ref:`intro_threads`
+        Args:
+            admin_ids: One or more user IDs to remove admin
+            thread_id: Group ID to remove people from. See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         self._adminStatus(admin_ids, False, thread_id)
@@ -1550,8 +1592,9 @@ class Client(object):
     def changeGroupApprovalMode(self, require_admin_approval, thread_id=None):
         """Change group's approval mode.
 
-        :param require_admin_approval: True or False
-        :param thread_id: Group ID to remove people from. See :ref:`intro_threads`
+        Args:
+            require_admin_approval: True or False
+            thread_id: Group ID to remove people from. See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
@@ -1579,8 +1622,9 @@ class Client(object):
     def acceptUsersToGroup(self, user_ids, thread_id=None):
         """Accept users to the group from the group's approval.
 
-        :param user_ids: One or more user IDs to accept
-        :param thread_id: Group ID to accept users to. See :ref:`intro_threads`
+        Args:
+            user_ids: One or more user IDs to accept
+            thread_id: Group ID to accept users to. See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         self._usersApproval(user_ids, True, thread_id)
@@ -1588,8 +1632,9 @@ class Client(object):
     def denyUsersFromGroup(self, user_ids, thread_id=None):
         """Deny users from joining the group.
 
-        :param user_ids: One or more user IDs to deny
-        :param thread_id: Group ID to deny users from. See :ref:`intro_threads`
+        Args:
+            user_ids: One or more user IDs to deny
+            thread_id: Group ID to deny users from. See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         self._usersApproval(user_ids, False, thread_id)
@@ -1597,8 +1642,9 @@ class Client(object):
     def _changeGroupImage(self, image_id, thread_id=None):
         """Change a thread image from an image id.
 
-        :param image_id: ID of uploaded image
-        :param thread_id: User/Group ID to change image. See :ref:`intro_threads`
+        Args:
+            image_id: ID of uploaded image
+            thread_id: User/Group ID to change image. See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
@@ -1611,8 +1657,9 @@ class Client(object):
     def changeGroupImageRemote(self, image_url, thread_id=None):
         """Change a thread image from a URL.
 
-        :param image_url: URL of an image to upload and change
-        :param thread_id: User/Group ID to change image. See :ref:`intro_threads`
+        Args:
+            image_url: URL of an image to upload and change
+            thread_id: User/Group ID to change image. See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         (image_id, mimetype), = self._upload(get_files_from_urls([image_url]))
@@ -1621,8 +1668,9 @@ class Client(object):
     def changeGroupImageLocal(self, image_path, thread_id=None):
         """Change a thread image from a local path.
 
-        :param image_path: Path of an image to upload and change
-        :param thread_id: User/Group ID to change image. See :ref:`intro_threads`
+        Args:
+            image_path: Path of an image to upload and change
+            thread_id: User/Group ID to change image. See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         with get_files_from_paths([image_path]) as files:
@@ -1636,9 +1684,10 @@ class Client(object):
         If this is executed on a user thread, this will change the nickname of that
         user, effectively changing the title.
 
-        :param title: New group thread title
-        :param thread_id: Group ID to change title of. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            title: New group thread title
+            thread_id: Group ID to change title of. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type thread_type: ThreadType
         :raises: FBchatException if request failed
         """
@@ -1658,10 +1707,11 @@ class Client(object):
     ):
         """Change the nickname of a user in a thread.
 
-        :param nickname: New nickname
-        :param user_id: User that will have their nickname changed
-        :param thread_id: User/Group ID to change color of. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            nickname: New nickname
+            user_id: User that will have their nickname changed
+            thread_id: User/Group ID to change color of. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type thread_type: ThreadType
         :raises: FBchatException if request failed
         """
@@ -1679,8 +1729,9 @@ class Client(object):
     def changeThreadColor(self, color, thread_id=None):
         """Change thread color.
 
-        :param color: New thread color
-        :param thread_id: User/Group ID to change color of. See :ref:`intro_threads`
+        Args:
+            color: New thread color
+            thread_id: User/Group ID to change color of. See :ref:`intro_threads`
         :type color: ThreadColor
         :raises: FBchatException if request failed
         """
@@ -1701,8 +1752,9 @@ class Client(object):
             While changing the emoji, the Facebook web client actually sends multiple
             different requests, though only this one is required to make the change.
 
-        :param color: New thread emoji
-        :param thread_id: User/Group ID to change emoji of. See :ref:`intro_threads`
+        Args:
+            color: New thread emoji
+            thread_id: User/Group ID to change emoji of. See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
@@ -1715,8 +1767,9 @@ class Client(object):
     def reactToMessage(self, message_id, reaction):
         """React to a message, or removes reaction.
 
-        :param message_id: :ref:`Message ID <intro_message_ids>` to react to
-        :param reaction: Reaction emoji to use, if None removes reaction
+        Args:
+            message_id: :ref:`Message ID <intro_message_ids>` to react to
+            reaction: Reaction emoji to use, if None removes reaction
         :type reaction: MessageReaction or None
         :raises: FBchatException if request failed
         """
@@ -1734,8 +1787,9 @@ class Client(object):
     def createPlan(self, plan, thread_id=None):
         """Set a plan.
 
-        :param plan: Plan to set
-        :param thread_id: User/Group ID to send plan to. See :ref:`intro_threads`
+        Args:
+            plan: Plan to set
+            thread_id: User/Group ID to send plan to. See :ref:`intro_threads`
         :type plan: Plan
         :raises: FBchatException if request failed
         """
@@ -1760,8 +1814,9 @@ class Client(object):
     def editPlan(self, plan, new_plan):
         """Edit a plan.
 
-        :param plan: Plan to edit
-        :param new_plan: New plan
+        Args:
+            plan: Plan to edit
+            new_plan: New plan
         :type plan: Plan
         :raises: FBchatException if request failed
         """
@@ -1779,7 +1834,8 @@ class Client(object):
     def deletePlan(self, plan):
         """Delete a plan.
 
-        :param plan: Plan to delete
+        Args:
+            plan: Plan to delete
         :raises: FBchatException if request failed
         """
         data = {"event_reminder_id": plan.uid, "delete": "true", "acontext": ACONTEXT}
@@ -1788,8 +1844,9 @@ class Client(object):
     def changePlanParticipation(self, plan, take_part=True):
         """Change participation in a plan.
 
-        :param plan: Plan to take part in or not
-        :param take_part: Whether to take part in the plan
+        Args:
+            plan: Plan to take part in or not
+            take_part: Whether to take part in the plan
         :raises: FBchatException if request failed
         """
         data = {
@@ -1807,8 +1864,9 @@ class Client(object):
     def createPoll(self, poll, thread_id=None):
         """Create poll in a group thread.
 
-        :param poll: Poll to create
-        :param thread_id: User/Group ID to create poll in. See :ref:`intro_threads`
+        Args:
+            poll: Poll to create
+            thread_id: User/Group ID to create poll in. See :ref:`intro_threads`
         :type poll: Poll
         :raises: FBchatException if request failed
         """
@@ -1834,11 +1892,12 @@ class Client(object):
     def updatePollVote(self, poll_id, option_ids=[], new_options=[]):
         """Update a poll vote.
 
-        :param poll_id: ID of the poll to update vote
-        :param option_ids: List of the option IDs to vote
-        :param new_options: List of the new option names
-        :param thread_id: User/Group ID to change status in. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            poll_id: ID of the poll to update vote
+            option_ids: List of the option IDs to vote
+            new_options: List of the new option names
+            thread_id: User/Group ID to change status in. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type thread_type: ThreadType
         :raises: FBchatException if request failed
         """
@@ -1860,9 +1919,10 @@ class Client(object):
     def setTypingStatus(self, status, thread_id=None, thread_type=None):
         """Set users typing status in a thread.
 
-        :param status: Specify the typing status
-        :param thread_id: User/Group ID to change status in. See :ref:`intro_threads`
-        :param thread_type: See :ref:`intro_threads`
+        Args:
+            status: Specify the typing status
+            thread_id: User/Group ID to change status in. See :ref:`intro_threads`
+            thread_type: See :ref:`intro_threads`
         :type status: TypingStatus
         :type thread_type: ThreadType
         :raises: FBchatException if request failed
@@ -1884,8 +1944,9 @@ class Client(object):
     def markAsDelivered(self, thread_id, message_id):
         """Mark a message as delivered.
 
-        :param thread_id: User/Group ID to which the message belongs. See :ref:`intro_threads`
-        :param message_id: Message ID to set as delivered. See :ref:`intro_threads`
+        Args:
+            thread_id: User/Group ID to which the message belongs. See :ref:`intro_threads`
+            message_id: Message ID to set as delivered. See :ref:`intro_threads`
         :return: True
         :raises: FBchatException if request failed
         """
@@ -1912,7 +1973,8 @@ class Client(object):
 
         All messages inside the specified threads will be marked as read.
 
-        :param thread_ids: User/Group IDs to set as read. See :ref:`intro_threads`
+        Args:
+            thread_ids: User/Group IDs to set as read. See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         self._readStatus(True, thread_ids)
@@ -1922,7 +1984,8 @@ class Client(object):
 
         All messages inside the specified threads will be marked as unread.
 
-        :param thread_ids: User/Group IDs to set as unread. See :ref:`intro_threads`
+        Args:
+            thread_ids: User/Group IDs to set as unread. See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         self._readStatus(False, thread_ids)
@@ -1946,7 +2009,8 @@ class Client(object):
     def removeFriend(self, friend_id=None):
         """Remove a specifed friend from the client's friend list.
 
-        :param friend_id: The ID of the friend that you want to remove
+        Args:
+            friend_id: The ID of the friend that you want to remove
         :return: True
         :raises: FBchatException if request failed
         """
@@ -1957,7 +2021,8 @@ class Client(object):
     def blockUser(self, user_id):
         """Block messages from a specifed user.
 
-        :param user_id: The ID of the user that you want to block
+        Args:
+            user_id: The ID of the user that you want to block
         :return: True
         :raises: FBchatException if request failed
         """
@@ -1968,7 +2033,8 @@ class Client(object):
     def unblockUser(self, user_id):
         """Unblock a previously blocked user.
 
-        :param user_id: The ID of the user that you want to unblock
+        Args:
+            user_id: The ID of the user that you want to unblock
         :return: Whether the request was successful
         :raises: FBchatException if request failed
         """
@@ -1979,8 +2045,9 @@ class Client(object):
     def moveThreads(self, location, thread_ids):
         """Move threads to specifed location.
 
-        :param location: ThreadLocation: INBOX, PENDING, ARCHIVED or OTHER
-        :param thread_ids: Thread IDs to move. See :ref:`intro_threads`
+        Args:
+            location (ThreadLocation): INBOX, PENDING, ARCHIVED or OTHER
+            thread_ids: Thread IDs to move. See :ref:`intro_threads`
         :return: True
         :raises: FBchatException if request failed
         """
@@ -2011,7 +2078,8 @@ class Client(object):
     def deleteThreads(self, thread_ids):
         """Delete threads.
 
-        :param thread_ids: Thread IDs to delete. See :ref:`intro_threads`
+        Args:
+            thread_ids: Thread IDs to delete. See :ref:`intro_threads`
         :return: True
         :raises: FBchatException if request failed
         """
@@ -2033,7 +2101,8 @@ class Client(object):
     def markAsSpam(self, thread_id=None):
         """Mark a thread as spam, and delete it.
 
-        :param thread_id: User/Group ID to mark as spam. See :ref:`intro_threads`
+        Args:
+            thread_id: User/Group ID to mark as spam. See :ref:`intro_threads`
         :return: True
         :raises: FBchatException if request failed
         """
@@ -2044,7 +2113,8 @@ class Client(object):
     def deleteMessages(self, message_ids):
         """Delete specifed messages.
 
-        :param message_ids: Message IDs to delete
+        Args:
+            message_ids: Message IDs to delete
         :return: True
         :raises: FBchatException if request failed
         """
@@ -2058,8 +2128,9 @@ class Client(object):
     def muteThread(self, mute_time=-1, thread_id=None):
         """Mute thread.
 
-        :param mute_time: Mute time in seconds, leave blank to mute forever
-        :param thread_id: User/Group ID to mute. See :ref:`intro_threads`
+        Args:
+            mute_time: Mute time in seconds, leave blank to mute forever
+            thread_id: User/Group ID to mute. See :ref:`intro_threads`
         """
         thread_id, thread_type = self._getThread(thread_id, None)
         data = {"mute_settings": str(mute_time), "thread_fbid": thread_id}
@@ -2068,15 +2139,17 @@ class Client(object):
     def unmuteThread(self, thread_id=None):
         """Unmute thread.
 
-        :param thread_id: User/Group ID to unmute. See :ref:`intro_threads`
+        Args:
+            thread_id: User/Group ID to unmute. See :ref:`intro_threads`
         """
         return self.muteThread(0, thread_id)
 
     def muteThreadReactions(self, mute=True, thread_id=None):
         """Mute thread reactions.
 
-        :param mute: Boolean. True to mute, False to unmute
-        :param thread_id: User/Group ID to mute. See :ref:`intro_threads`
+        Args:
+            mute: Boolean. True to mute, False to unmute
+            thread_id: User/Group ID to mute. See :ref:`intro_threads`
         """
         thread_id, thread_type = self._getThread(thread_id, None)
         data = {"reactions_mute_mode": int(mute), "thread_fbid": thread_id}
@@ -2087,15 +2160,17 @@ class Client(object):
     def unmuteThreadReactions(self, thread_id=None):
         """Unmute thread reactions.
 
-        :param thread_id: User/Group ID to unmute. See :ref:`intro_threads`
+        Args:
+            thread_id: User/Group ID to unmute. See :ref:`intro_threads`
         """
         return self.muteThreadReactions(False, thread_id)
 
     def muteThreadMentions(self, mute=True, thread_id=None):
         """Mute thread mentions.
 
-        :param mute: Boolean. True to mute, False to unmute
-        :param thread_id: User/Group ID to mute. See :ref:`intro_threads`
+        Args:
+            mute: Boolean. True to mute, False to unmute
+            thread_id: User/Group ID to mute. See :ref:`intro_threads`
         """
         thread_id, thread_type = self._getThread(thread_id, None)
         data = {"mentions_mute_mode": int(mute), "thread_fbid": thread_id}
@@ -2104,7 +2179,8 @@ class Client(object):
     def unmuteThreadMentions(self, thread_id=None):
         """Unmute thread mentions.
 
-        :param thread_id: User/Group ID to unmute. See :ref:`intro_threads`
+        Args:
+            thread_id: User/Group ID to unmute. See :ref:`intro_threads`
         """
         return self.muteThreadMentions(False, thread_id)
 
@@ -2854,7 +2930,8 @@ class Client(object):
     def listen(self, markAlive=None):
         """Initialize and runs the listening loop continually.
 
-        :param markAlive: Whether this should ping the Facebook server each time the loop runs
+        Args:
+            markAlive: Whether this should ping the Facebook server each time the loop runs
         :type markAlive: bool
         """
         if markAlive is not None:
@@ -2871,7 +2948,8 @@ class Client(object):
     def setActiveStatus(self, markAlive):
         """Change active status while listening.
 
-        :param markAlive: Whether to show if client is active
+        Args:
+            markAlive: Whether to show if client is active
         :type markAlive: bool
         """
         self._markAlive = markAlive
@@ -2887,7 +2965,8 @@ class Client(object):
     def onLoggingIn(self, email=None):
         """Called when the client is logging in.
 
-        :param email: The email of the client
+        Args:
+            email: The email of the client
         """
         log.info("Logging in {}...".format(email))
 
@@ -2898,7 +2977,8 @@ class Client(object):
     def onLoggedIn(self, email=None):
         """Called when the client is successfully logged in.
 
-        :param email: The email of the client
+        Args:
+            email: The email of the client
         """
         log.info("Login of {} successful.".format(email))
 
@@ -2909,7 +2989,8 @@ class Client(object):
     def onListenError(self, exception=None):
         """Called when an error was encountered while listening.
 
-        :param exception: The exception that was encountered
+        Args:
+            exception: The exception that was encountered
         :return: Whether the loop should keep running
         """
         log.exception("Got exception while listening")
@@ -2929,15 +3010,16 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody sends a message.
 
-        :param mid: The message ID
-        :param author_id: The ID of the author
-        :param message: (deprecated. Use ``message_object.text`` instead)
-        :param message_object: The message (As a `Message` object)
-        :param thread_id: Thread ID that the message was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the message was sent to. See :ref:`intro_threads`
-        :param ts: The timestamp of the message
-        :param metadata: Extra metadata about the message
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The message ID
+            author_id: The ID of the author
+            message: (deprecated. Use ``message_object.text`` instead)
+            message_object: The message (As a `Message` object)
+            thread_id: Thread ID that the message was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the message was sent to. See :ref:`intro_threads`
+            ts: The timestamp of the message
+            metadata: Extra metadata about the message
+            msg: A full set of the data recieved
         :type message_object: Message
         :type thread_type: ThreadType
         """
@@ -2956,14 +3038,15 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody changes a thread's color.
 
-        :param mid: The action ID
-        :param author_id: The ID of the person who changed the color
-        :param new_color: The new color
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            author_id: The ID of the person who changed the color
+            new_color: The new color
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type new_color: ThreadColor
         :type thread_type: ThreadType
         """
@@ -2986,14 +3069,15 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody changes a thread's emoji.
 
-        :param mid: The action ID
-        :param author_id: The ID of the person who changed the emoji
-        :param new_emoji: The new emoji
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            author_id: The ID of the person who changed the emoji
+            new_emoji: The new emoji
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3015,14 +3099,15 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody changes a thread's title.
 
-        :param mid: The action ID
-        :param author_id: The ID of the person who changed the title
-        :param new_title: The new title
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            author_id: The ID of the person who changed the title
+            new_title: The new title
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3043,13 +3128,14 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody changes a thread's image.
 
-        :param mid: The action ID
-        :param author_id: The ID of the person who changed the image
-        :param new_image: The ID of the new image
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            author_id: The ID of the person who changed the image
+            new_image: The ID of the new image
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info("{} changed thread image in {}".format(author_id, thread_id))
@@ -3068,15 +3154,16 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody changes a nickname.
 
-        :param mid: The action ID
-        :param author_id: The ID of the person who changed the nickname
-        :param changed_for: The ID of the person whom got their nickname changed
-        :param new_nickname: The new nickname
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            author_id: The ID of the person who changed the nickname
+            changed_for: The ID of the person whom got their nickname changed
+            new_nickname: The new nickname
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3097,12 +3184,13 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody adds an admin to a group.
 
-        :param mid: The action ID
-        :param added_id: The ID of the admin who got added
-        :param author_id: The ID of the person who added the admins
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            added_id: The ID of the admin who got added
+            author_id: The ID of the person who added the admins
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            msg: A full set of the data recieved
         """
         log.info("{} added admin: {} in {}".format(author_id, added_id, thread_id))
 
@@ -3118,12 +3206,13 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody is removed as an admin in a group.
 
-        :param mid: The action ID
-        :param removed_id: The ID of the admin who got removed
-        :param author_id: The ID of the person who removed the admins
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            removed_id: The ID of the admin who got removed
+            author_id: The ID of the person who removed the admins
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            msg: A full set of the data recieved
         """
         log.info("{} removed admin: {} in {}".format(author_id, removed_id, thread_id))
 
@@ -3139,12 +3228,13 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody changes approval mode in a group.
 
-        :param mid: The action ID
-        :param approval_mode: True if approval mode is activated
-        :param author_id: The ID of the person who changed approval mode
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            approval_mode: True if approval mode is activated
+            author_id: The ID of the person who changed approval mode
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            msg: A full set of the data recieved
         """
         if approval_mode:
             log.info("{} activated approval mode in {}".format(author_id, thread_id))
@@ -3163,13 +3253,14 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody marks a message as seen.
 
-        :param seen_by: The ID of the person who marked the message as seen
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param seen_ts: A timestamp of when the person saw the message
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            seen_by: The ID of the person who marked the message as seen
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            seen_ts: A timestamp of when the person saw the message
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3190,13 +3281,14 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody marks messages as delivered.
 
-        :param msg_ids: The messages that are marked as delivered
-        :param delivered_for: The person that marked the messages as delivered
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            msg_ids: The messages that are marked as delivered
+            delivered_for: The person that marked the messages as delivered
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3210,12 +3302,13 @@ class Client(object):
     ):
         """Called when the client is listening, and the client has successfully marked threads as seen.
 
-        :param threads: The threads that were marked
-        :param author_id: The ID of the person who changed the emoji
-        :param seen_ts: A timestamp of when the threads were seen
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            threads: The threads that were marked
+            author_id: The ID of the person who changed the emoji
+            seen_ts: A timestamp of when the threads were seen
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3235,12 +3328,13 @@ class Client(object):
     ):
         """Called when the client is listening, and someone unsends (deletes for everyone) a message.
 
-        :param mid: ID of the unsent message
-        :param author_id: The ID of the person who unsent the message
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: ID of the unsent message
+            author_id: The ID of the person who unsent the message
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3260,12 +3354,13 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody adds people to a group thread.
 
-        :param mid: The action ID
-        :param added_ids: The IDs of the people who got added
-        :param author_id: The ID of the person who added the people
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            added_ids: The IDs of the people who got added
+            author_id: The ID of the person who added the people
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            msg: A full set of the data recieved
         """
         log.info(
             "{} added: {} in {}".format(author_id, ", ".join(added_ids), thread_id)
@@ -3282,20 +3377,22 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody removes a person from a group thread.
 
-        :param mid: The action ID
-        :param removed_id: The ID of the person who got removed
-        :param author_id: The ID of the person who removed the person
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            removed_id: The ID of the person who got removed
+            author_id: The ID of the person who removed the person
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            msg: A full set of the data recieved
         """
         log.info("{} removed: {} in {}".format(author_id, removed_id, thread_id))
 
     def onFriendRequest(self, from_id=None, msg=None):
         """Called when the client is listening, and somebody sends a friend request.
 
-        :param from_id: The ID of the person that sent the request
-        :param msg: A full set of the data recieved
+        Args:
+            from_id: The ID of the person that sent the request
+            msg: A full set of the data recieved
         """
         log.info("Friend request from {}".format(from_id))
 
@@ -3304,10 +3401,11 @@ class Client(object):
         .. todo::
             Documenting this
 
-        :param unseen: --
-        :param unread: --
-        :param recent_unread: --
-        :param msg: A full set of the data recieved
+        Args:
+            unseen: --
+            unread: --
+            recent_unread: --
+            msg: A full set of the data recieved
         """
         log.info("Inbox event: {}, {}, {}".format(unseen, unread, recent_unread))
 
@@ -3316,11 +3414,12 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody starts or stops typing into a chat.
 
-        :param author_id: The ID of the person who sent the action
-        :param status: The typing status
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param msg: A full set of the data recieved
+        Args:
+            author_id: The ID of the person who sent the action
+            status: The typing status
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            msg: A full set of the data recieved
         :type typing_status: TypingStatus
         :type thread_type: ThreadType
         """
@@ -3342,17 +3441,18 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody plays a game.
 
-        :param mid: The action ID
-        :param author_id: The ID of the person who played the game
-        :param game_id: The ID of the game
-        :param game_name: Name of the game
-        :param score: Score obtained in the game
-        :param leaderboard: Actual leaderboard of the game in the thread
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            author_id: The ID of the person who played the game
+            game_id: The ID of the game
+            game_name: Name of the game
+            score: Score obtained in the game
+            leaderboard: Actual leaderboard of the game in the thread
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3373,14 +3473,15 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody reacts to a message.
 
-        :param mid: Message ID, that user reacted to
-        :param reaction: Reaction
-        :param add_reaction: Whether user added or removed reaction
-        :param author_id: The ID of the person who reacted to the message
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: Message ID, that user reacted to
+            reaction: Reaction
+            add_reaction: Whether user added or removed reaction
+            author_id: The ID of the person who reacted to the message
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            msg: A full set of the data recieved
         :type reaction: MessageReaction
         :type thread_type: ThreadType
         """
@@ -3401,12 +3502,13 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody removes reaction from a message.
 
-        :param mid: Message ID, that user reacted to
-        :param author_id: The ID of the person who removed reaction
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: Message ID, that user reacted to
+            author_id: The ID of the person who removed reaction
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3420,11 +3522,12 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody blocks client.
 
-        :param author_id: The ID of the person who blocked
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param msg: A full set of the data recieved
+        Args:
+            author_id: The ID of the person who blocked
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3436,11 +3539,12 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody blocks client.
 
-        :param author_id: The ID of the person who unblocked
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param msg: A full set of the data recieved
+        Args:
+            author_id: The ID of the person who unblocked
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3459,13 +3563,14 @@ class Client(object):
     ):
         """Called when the client is listening and somebody sends live location info.
 
-        :param mid: The action ID
-        :param location: Sent location info
-        :param author_id: The ID of the person who sent location info
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            location: Sent location info
+            author_id: The ID of the person who sent location info
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            msg: A full set of the data recieved
         :type location: LiveLocationAttachment
         :type thread_type: ThreadType
         """
@@ -3491,14 +3596,15 @@ class Client(object):
         .. todo::
             Make this work with private calls.
 
-        :param mid: The action ID
-        :param caller_id: The ID of the person who started the call
-        :param is_video_call: True if it's video call
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            caller_id: The ID of the person who started the call
+            is_video_call: True if it's video call
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3522,15 +3628,16 @@ class Client(object):
         .. todo::
             Make this work with private calls.
 
-        :param mid: The action ID
-        :param caller_id: The ID of the person who ended the call
-        :param is_video_call: True if it was video call
-        :param call_duration: Call duration in seconds
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            caller_id: The ID of the person who ended the call
+            is_video_call: True if it was video call
+            call_duration: Call duration in seconds
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3550,14 +3657,15 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody joins a group call.
 
-        :param mid: The action ID
-        :param joined_id: The ID of the person who joined the call
-        :param is_video_call: True if it's video call
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            joined_id: The ID of the person who joined the call
+            is_video_call: True if it's video call
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type thread_type: ThreadType
         """
         log.info(
@@ -3577,14 +3685,15 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody creates a group poll.
 
-        :param mid: The action ID
-        :param poll: Created poll
-        :param author_id: The ID of the person who created the poll
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            poll: Created poll
+            author_id: The ID of the person who created the poll
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type poll: Poll
         :type thread_type: ThreadType
         """
@@ -3609,14 +3718,15 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody votes in a group poll.
 
-        :param mid: The action ID
-        :param poll: Poll, that user voted in
-        :param author_id: The ID of the person who voted in the poll
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            poll: Poll, that user voted in
+            author_id: The ID of the person who voted in the poll
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type poll: Poll
         :type thread_type: ThreadType
         """
@@ -3639,14 +3749,15 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody creates a plan.
 
-        :param mid: The action ID
-        :param plan: Created plan
-        :param author_id: The ID of the person who created the plan
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            plan: Created plan
+            author_id: The ID of the person who created the plan
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type plan: Plan
         :type thread_type: ThreadType
         """
@@ -3668,13 +3779,14 @@ class Client(object):
     ):
         """Called when the client is listening, and a plan ends.
 
-        :param mid: The action ID
-        :param plan: Ended plan
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            plan: Ended plan
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type plan: Plan
         :type thread_type: ThreadType
         """
@@ -3695,14 +3807,15 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody edits a plan.
 
-        :param mid: The action ID
-        :param plan: Edited plan
-        :param author_id: The ID of the person who edited the plan
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            plan: Edited plan
+            author_id: The ID of the person who edited the plan
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type plan: Plan
         :type thread_type: ThreadType
         """
@@ -3725,14 +3838,15 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody deletes a plan.
 
-        :param mid: The action ID
-        :param plan: Deleted plan
-        :param author_id: The ID of the person who deleted the plan
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            plan: Deleted plan
+            author_id: The ID of the person who deleted the plan
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type plan: Plan
         :type thread_type: ThreadType
         """
@@ -3756,15 +3870,16 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody takes part in a plan or not.
 
-        :param mid: The action ID
-        :param plan: Plan
-        :param take_part: Whether the person takes part in the plan or not
-        :param author_id: The ID of the person who will participate in the plan or not
-        :param thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-        :param thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
-        :param ts: A timestamp of the action
-        :param metadata: Extra metadata about the action
-        :param msg: A full set of the data recieved
+        Args:
+            mid: The action ID
+            plan: Plan
+            take_part: Whether the person takes part in the plan or not
+            author_id: The ID of the person who will participate in the plan or not
+            thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
+            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            ts: A timestamp of the action
+            metadata: Extra metadata about the action
+            msg: A full set of the data recieved
         :type plan: Plan
         :type take_part: bool
         :type thread_type: ThreadType
@@ -3785,24 +3900,27 @@ class Client(object):
     def onQprimer(self, ts=None, msg=None):
         """Called when the client just started listening.
 
-        :param ts: A timestamp of the action
-        :param msg: A full set of the data recieved
+        Args:
+            ts: A timestamp of the action
+            msg: A full set of the data recieved
         """
         pass
 
     def onChatTimestamp(self, buddylist=None, msg=None):
         """Called when the client receives chat online presence update.
 
-        :param buddylist: A list of dicts with friend id and last seen timestamp
-        :param msg: A full set of the data recieved
+        Args:
+            buddylist: A list of dicts with friend id and last seen timestamp
+            msg: A full set of the data recieved
         """
         log.debug("Chat Timestamps received: {}".format(buddylist))
 
     def onBuddylistOverlay(self, statuses=None, msg=None):
         """Called when the client is listening and client receives information about friend active status.
 
-        :param statuses: Dictionary with user IDs as keys and :class:`ActiveStatus` as values
-        :param msg: A full set of the data recieved
+        Args:
+            statuses: Dictionary with user IDs as keys and :class:`ActiveStatus` as values
+            msg: A full set of the data recieved
         :type statuses: dict
         """
         log.debug("Buddylist overlay received: {}".format(statuses))
@@ -3810,15 +3928,17 @@ class Client(object):
     def onUnknownMesssageType(self, msg=None):
         """Called when the client is listening, and some unknown data was recieved.
 
-        :param msg: A full set of the data recieved
+        Args:
+            msg: A full set of the data recieved
         """
         log.debug("Unknown message received: {}".format(msg))
 
     def onMessageError(self, exception=None, msg=None):
         """Called when an error was encountered while parsing recieved data.
 
-        :param exception: The exception that was encountered
-        :param msg: A full set of the data recieved
+        Args:
+            exception: The exception that was encountered
+            msg: A full set of the data recieved
         """
         log.exception("Exception in parsing of {}".format(msg))
 

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -358,7 +358,7 @@ class Client(object):
             limit: The max. amount of threads to fetch (default all threads)
 
         Returns:
-            list: :class:`Thread` objects
+            list: `Thread` objects
 
         Raises:
             FBchatException: If request failed
@@ -410,7 +410,7 @@ class Client(object):
             threads: Thread: List of threads to check for users
 
         Returns:
-            list: :class:`User` objects
+            list: `User` objects
 
         Raises:
             FBchatException: If request failed
@@ -436,7 +436,7 @@ class Client(object):
         """Fetch all users the client is currently chatting with.
 
         Returns:
-            list: :class:`User` objects
+            list: `User` objects
 
         Raises:
             FBchatException: If request failed
@@ -461,7 +461,7 @@ class Client(object):
             limit: The max. amount of users to fetch
 
         Returns:
-            list: :class:`User` objects, ordered by relevance
+            list: `User` objects, ordered by relevance
 
         Raises:
             FBchatException: If request failed
@@ -478,7 +478,7 @@ class Client(object):
             name: Name of the page
 
         Returns:
-            list: :class:`Page` objects, ordered by relevance
+            list: `Page` objects, ordered by relevance
 
         Raises:
             FBchatException: If request failed
@@ -496,7 +496,7 @@ class Client(object):
             limit: The max. amount of groups to fetch
 
         Returns:
-            list: :class:`Group` objects, ordered by relevance
+            list: `Group` objects, ordered by relevance
 
         Raises:
             FBchatException: If request failed
@@ -514,7 +514,7 @@ class Client(object):
             limit: The max. amount of groups to fetch
 
         Returns:
-            list: :class:`User`, :class:`Group` and :class:`Page` objects, ordered by relevance
+            list: `User`, `Group` and `Page` objects, ordered by relevance
 
         Raises:
             FBchatException: If request failed
@@ -585,7 +585,7 @@ class Client(object):
             thread_id: User/Group ID to search in. See :ref:`intro_threads`
 
         Returns:
-            typing.Iterable: Found :class:`Message` objects
+            typing.Iterable: Found `Message` objects
 
         Raises:
             FBchatException: If request failed
@@ -601,7 +601,7 @@ class Client(object):
 
         Args:
             query: Text to search for
-            fetch_messages: Whether to fetch :class:`Message` objects or IDs only
+            fetch_messages: Whether to fetch `Message` objects or IDs only
             thread_limit (int): Max. number of threads to retrieve
             message_limit (int): Max. number of messages to retrieve
 
@@ -675,7 +675,7 @@ class Client(object):
             user_ids: One or more user ID(s) to query
 
         Returns:
-            dict: :class:`User` objects, labeled by their ID
+            dict: `User` objects, labeled by their ID
 
         Raises:
             FBchatException: If request failed
@@ -700,7 +700,7 @@ class Client(object):
             page_ids: One or more page ID(s) to query
 
         Returns:
-            dict: :class:`Page` objects, labeled by their ID
+            dict: `Page` objects, labeled by their ID
 
         Raises:
             FBchatException: If request failed
@@ -722,7 +722,7 @@ class Client(object):
             group_ids: One or more group ID(s) to query
 
         Returns:
-            dict: :class:`Group` objects, labeled by their ID
+            dict: `Group` objects, labeled by their ID
 
         Raises:
             FBchatException: If request failed
@@ -747,7 +747,7 @@ class Client(object):
             thread_ids: One or more thread ID(s) to query
 
         Returns:
-            dict: :class:`Thread` objects, labeled by their ID
+            dict: `Thread` objects, labeled by their ID
 
         Raises:
             FBchatException: If request failed
@@ -813,7 +813,7 @@ class Client(object):
             before (int): A timestamp, indicating from which point to retrieve messages
 
         Returns:
-            list: :class:`Message` objects
+            list: `Message` objects
 
         Raises:
             FBchatException: If request failed
@@ -859,7 +859,7 @@ class Client(object):
             before (int): A timestamp (in milliseconds), indicating from which point to retrieve threads
 
         Returns:
-            list: :class:`Thread` objects
+            list: `Thread` objects
 
         Raises:
             FBchatException: If request failed
@@ -964,7 +964,7 @@ class Client(object):
             thread_id: User/Group ID to get message info from. See :ref:`intro_threads`
 
         Returns:
-            Message: :class:`Message` object
+            Message: `Message` object
 
         Raises:
             FBchatException: If request failed
@@ -996,7 +996,7 @@ class Client(object):
             plan_id: Plan ID to fetch from
 
         Returns:
-            Plan: :class:`Plan` object
+            Plan: `Plan` object
 
         Raises:
             FBchatException: If request failed
@@ -1052,7 +1052,7 @@ class Client(object):
             thread_id: ID of the thread
 
         Returns:
-            typing.Iterable: :class:`ImageAttachment` or :class:`VideoAttachment`
+            typing.Iterable: `ImageAttachment` or `VideoAttachment`
         """
         thread_id, thread_type = self._getThread(thread_id, None)
         data = {"id": thread_id, "first": 48}
@@ -1211,7 +1211,7 @@ class Client(object):
         return self._doSendRequest(data)
 
     def sendMessage(self, message, thread_id=None, thread_type=ThreadType.USER):
-        """Deprecated. Use :func:`fbchat.Client.send` instead."""
+        """Deprecated. Use `Client.send` instead."""
         return self.send(
             Message(text=message), thread_id=thread_id, thread_type=thread_type
         )
@@ -1223,7 +1223,7 @@ class Client(object):
         thread_id=None,
         thread_type=ThreadType.USER,
     ):
-        """Deprecated. Use :func:`fbchat.Client.send` instead."""
+        """Deprecated. Use `Client.send` instead."""
         return self.send(
             Message(text=emoji, emoji_size=size),
             thread_id=thread_id,
@@ -1531,7 +1531,7 @@ class Client(object):
     def sendRemoteImage(
         self, image_url, message=None, thread_id=None, thread_type=ThreadType.USER
     ):
-        """Deprecated. Use :func:`fbchat.Client.sendRemoteFiles` instead."""
+        """Deprecated. Use `Client.sendRemoteFiles` instead."""
         return self.sendRemoteFiles(
             file_urls=[image_url],
             message=message,
@@ -1542,7 +1542,7 @@ class Client(object):
     def sendLocalImage(
         self, image_path, message=None, thread_id=None, thread_type=ThreadType.USER
     ):
-        """Deprecated. Use :func:`fbchat.Client.sendLocalFiles` instead."""
+        """Deprecated. Use `Client.sendLocalFiles` instead."""
         return self.sendLocalFiles(
             file_paths=[image_path],
             message=message,
@@ -1973,7 +1973,7 @@ class Client(object):
         j = self._payload_post("/ajax/eventreminder/rsvp", data)
 
     def eventReminder(self, thread_id, time, title, location="", location_id=""):
-        """Deprecated. Use :func:`fbchat.Client.createPlan` instead."""
+        """Deprecated. Use `Client.createPlan` instead."""
         plan = Plan(time=time, title=title, location=location, location_id=location_id)
         self.createPlan(plan=plan, thread_id=thread_id)
 
@@ -3043,8 +3043,8 @@ class Client(object):
         This method is useful if you want to control fbchat from an external event loop.
 
         Warning:
-            ``markAlive`` parameter is deprecated, use :func:`Client.setActiveStatus`
-            or ``markAlive`` parameter in :func:`Client.listen` instead.
+            ``markAlive`` parameter is deprecated, use `Client.setActiveStatus`
+            or ``markAlive`` parameter in `Client.listen` instead.
 
         Returns:
             bool: Whether the loop should keep running
@@ -4034,7 +4034,7 @@ class Client(object):
         """Called when the client is listening and client receives information about friend active status.
 
         Args:
-            statuses (dict): Dictionary with user IDs as keys and :class:`ActiveStatus` as values
+            statuses (dict): Dictionary with user IDs as keys and `ActiveStatus` as values
             msg: A full set of the data recieved
         """
         log.debug("Buddylist overlay received: {}".format(statuses))

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -78,12 +78,9 @@ class Client(object):
             email: Facebook ``email``, ``id`` or ``phone number``
             password: Facebook account password
             user_agent: Custom user agent to use when sending requests. If `None`, user agent will be chosen from a premade list
-            max_tries: Maximum number of times to try logging in
-            session_cookies: Cookies from a previous session (Will default to login if these are invalid)
-            logging_level: Configures the `logging level <https://docs.python.org/3/library/logging.html#logging-levels>`_. Defaults to ``logging.INFO``
-        :type max_tries: int
-        :type session_cookies: dict
-        :type logging_level: int
+            max_tries (int): Maximum number of times to try logging in
+            session_cookies (dict): Cookies from a previous session (Will default to login if these are invalid)
+            logging_level (int): Configures the `logging level <https://docs.python.org/3/library/logging.html#logging-levels>`_. Defaults to ``logging.INFO``
         :raises: FBchatException on failed login
         """
         self._sticky, self._pool = (None, None)
@@ -171,8 +168,7 @@ class Client(object):
         """Execute graphql queries.
 
         Args:
-            queries: Zero or more dictionaries
-        :type queries: dict
+            queries (dict): Zero or more dictionaries
 
         :raises: FBchatException if request failed
         :return: A tuple containing json graphql queries
@@ -220,8 +216,7 @@ class Client(object):
         """Load session cookies.
 
         Args:
-            session_cookies: A dictionay containing session cookies
-        :type session_cookies: dict
+            session_cookies (dict): A dictionay containing session cookies
         :return: False if ``session_cookies`` does not contain proper cookies
         :rtype: bool
         """
@@ -247,8 +242,7 @@ class Client(object):
         Args:
             email: Facebook ``email`` or ``id`` or ``phone number``
             password: Facebook account password
-            max_tries: Maximum number of times to try logging in
-        :type max_tries: int
+            max_tries (int): Maximum number of times to try logging in
         :raises: FBchatException on failed login
         """
         self.onLoggingIn(email=email)
@@ -321,8 +315,7 @@ class Client(object):
 
         Args:
             thread_id: User/Group ID to default to. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         """
         self._default_thread_id = thread_id
         self._default_thread_type = thread_type
@@ -523,11 +516,9 @@ class Client(object):
 
         Args:
             query: Text to search for
-            offset: Number of messages to skip
-            limit: Max. number of messages to retrieve
+            offset (int): Number of messages to skip
+            limit (int): Max. number of messages to retrieve
             thread_id: User/Group ID to search in. See :ref:`intro_threads`
-        :type offset: int
-        :type limit: int
         :return: Found Message IDs
         :rtype: typing.Iterable
         :raises: FBchatException if request failed
@@ -556,11 +547,9 @@ class Client(object):
 
         Args:
             query: Text to search for
-            offset: Number of messages to skip
-            limit: Max. number of messages to retrieve
+            offset (int): Number of messages to skip
+            limit (int): Max. number of messages to retrieve
             thread_id: User/Group ID to search in. See :ref:`intro_threads`
-        :type offset: int
-        :type limit: int
         :return: Found :class:`Message` objects
         :rtype: typing.Iterable
         :raises: FBchatException if request failed
@@ -577,10 +566,8 @@ class Client(object):
         Args:
             query: Text to search for
             fetch_messages: Whether to fetch :class:`Message` objects or IDs only
-            thread_limit: Max. number of threads to retrieve
-            message_limit: Max. number of messages to retrieve
-        :type thread_limit: int
-        :type message_limit: int
+            thread_limit (int): Max. number of threads to retrieve
+            message_limit (int): Max. number of messages to retrieve
         :return: Dictionary with thread IDs as keys and iterables to get messages as values
         :rtype: typing.Dict[str, typing.Iterable]
         :raises: FBchatException if request failed
@@ -771,10 +758,8 @@ class Client(object):
 
         Args:
             thread_id: User/Group ID to get messages from. See :ref:`intro_threads`
-            limit: Max. number of messages to retrieve
-            before: A timestamp, indicating from which point to retrieve messages
-        :type limit: int
-        :type before: int
+            limit (int): Max. number of messages to retrieve
+            before (int): A timestamp, indicating from which point to retrieve messages
         :return: :class:`Message` objects
         :rtype: list
         :raises: FBchatException if request failed
@@ -815,11 +800,9 @@ class Client(object):
 
         Args:
             offset: Deprecated. Do not use!
-            limit: Max. number of threads to retrieve. Capped at 20
+            limit (int): Max. number of threads to retrieve. Capped at 20
             thread_location (ThreadLocation): INBOX, PENDING, ARCHIVED or OTHER
-            before: A timestamp (in milliseconds), indicating from which point to retrieve threads
-        :type limit: int
-        :type before: int
+            before (int): A timestamp (in milliseconds), indicating from which point to retrieve threads
         :return: :class:`Thread` objects
         :rtype: list
         :raises: FBchatException if request failed
@@ -895,8 +878,7 @@ class Client(object):
         """Fetch url to download the original image from an image attachment ID.
 
         Args:
-            image_id: The image you want to fethc
-        :type image_id: str
+            image_id (str): The image you want to fethc
         :return: An url where you can download the original image
         :rtype: str
         :raises: FBchatException if request failed
@@ -1136,11 +1118,9 @@ class Client(object):
         """Send message to a thread.
 
         Args:
-            message: Message to send
+            message (Message): Message to send
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type message: Message
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent message
         :raises: FBchatException if request failed
         """
@@ -1176,8 +1156,7 @@ class Client(object):
         Args:
             wave_first: Whether to wave first or wave back
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent message
         :raises: FBchatException if request failed
         """
@@ -1196,12 +1175,10 @@ class Client(object):
         """Reply to chosen quick reply.
 
         Args:
-            quick_reply: Quick reply to reply to
+            quick_reply (QuickReply): Quick reply to reply to
             payload: Optional answer to the quick reply
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type quick_reply: QuickReply
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent message
         :raises: FBchatException if request failed
         """
@@ -1257,13 +1234,10 @@ class Client(object):
         """Send a given location to a thread as the user's current location.
 
         Args:
-            location: Location to send
-            message: Additional message
+            location (LocationAttachment): Location to send
+            message (Message): Additional message
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type location: LocationAttachment
-        :type message: Message
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent message
         :raises: FBchatException if request failed
         """
@@ -1281,13 +1255,10 @@ class Client(object):
         """Send a given location to a thread as a pinned location.
 
         Args:
-            location: Location to send
-            message: Additional message
+            location (LocationAttachment): Location to send
+            message (Message): Additional message
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type location: LocationAttachment
-        :type message: Message
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent message
         :raises: FBchatException if request failed
         """
@@ -1356,8 +1327,7 @@ class Client(object):
             file_urls: URLs of files to upload and send
             message: Additional message
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent files
         :raises: FBchatException if request failed
         """
@@ -1376,8 +1346,7 @@ class Client(object):
             file_paths: Paths of files to upload and send
             message: Additional message
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent files
         :raises: FBchatException if request failed
         """
@@ -1397,8 +1366,7 @@ class Client(object):
             clip_urls: URLs of clips to upload and send
             message: Additional message
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent files
         :raises: FBchatException if request failed
         """
@@ -1417,8 +1385,7 @@ class Client(object):
             clip_paths: Paths of clips to upload and send
             message: Additional message
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         :return: :ref:`Message ID <intro_message_ids>` of the sent files
         :raises: FBchatException if request failed
         """
@@ -1519,9 +1486,8 @@ class Client(object):
         """Add users to a group.
 
         Args:
-            user_ids: One or more user IDs to add
+            user_ids (list): One or more user IDs to add
             thread_id: Group ID to add people to. See :ref:`intro_threads`
-        :type user_ids: list
         :raises: FBchatException if request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
@@ -1687,8 +1653,7 @@ class Client(object):
         Args:
             title: New group thread title
             thread_id: Group ID to change title of. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         thread_id, thread_type = self._getThread(thread_id, thread_type)
@@ -1711,8 +1676,7 @@ class Client(object):
             nickname: New nickname
             user_id: User that will have their nickname changed
             thread_id: User/Group ID to change color of. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         thread_id, thread_type = self._getThread(thread_id, thread_type)
@@ -1730,9 +1694,8 @@ class Client(object):
         """Change thread color.
 
         Args:
-            color: New thread color
+            color (ThreadColor): New thread color
             thread_id: User/Group ID to change color of. See :ref:`intro_threads`
-        :type color: ThreadColor
         :raises: FBchatException if request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
@@ -1769,8 +1732,7 @@ class Client(object):
 
         Args:
             message_id: :ref:`Message ID <intro_message_ids>` to react to
-            reaction: Reaction emoji to use, if None removes reaction
-        :type reaction: MessageReaction or None
+            reaction (MessageReaction): Reaction emoji to use, if None removes reaction
         :raises: FBchatException if request failed
         """
         data = {
@@ -1788,9 +1750,8 @@ class Client(object):
         """Set a plan.
 
         Args:
-            plan: Plan to set
+            plan (Plan): Plan to set
             thread_id: User/Group ID to send plan to. See :ref:`intro_threads`
-        :type plan: Plan
         :raises: FBchatException if request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
@@ -1815,9 +1776,8 @@ class Client(object):
         """Edit a plan.
 
         Args:
-            plan: Plan to edit
+            plan (Plan): Plan to edit
             new_plan: New plan
-        :type plan: Plan
         :raises: FBchatException if request failed
         """
         data = {
@@ -1865,9 +1825,8 @@ class Client(object):
         """Create poll in a group thread.
 
         Args:
-            poll: Poll to create
+            poll (Poll): Poll to create
             thread_id: User/Group ID to create poll in. See :ref:`intro_threads`
-        :type poll: Poll
         :raises: FBchatException if request failed
         """
         thread_id, thread_type = self._getThread(thread_id, None)
@@ -1897,8 +1856,7 @@ class Client(object):
             option_ids: List of the option IDs to vote
             new_options: List of the new option names
             thread_id: User/Group ID to change status in. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         data = {"question_id": poll_id}
@@ -1920,11 +1878,9 @@ class Client(object):
         """Set users typing status in a thread.
 
         Args:
-            status: Specify the typing status
+            status (TypingStatus): Specify the typing status
             thread_id: User/Group ID to change status in. See :ref:`intro_threads`
-            thread_type: See :ref:`intro_threads`
-        :type status: TypingStatus
-        :type thread_type: ThreadType
+            thread_type (ThreadType): See :ref:`intro_threads`
         :raises: FBchatException if request failed
         """
         thread_id, thread_type = self._getThread(thread_id, thread_type)
@@ -2931,8 +2887,7 @@ class Client(object):
         """Initialize and runs the listening loop continually.
 
         Args:
-            markAlive: Whether this should ping the Facebook server each time the loop runs
-        :type markAlive: bool
+            markAlive (bool): Whether this should ping the Facebook server each time the loop runs
         """
         if markAlive is not None:
             self.setActiveStatus(markAlive)
@@ -2949,8 +2904,7 @@ class Client(object):
         """Change active status while listening.
 
         Args:
-            markAlive: Whether to show if client is active
-        :type markAlive: bool
+            markAlive (bool): Whether to show if client is active
         """
         self._markAlive = markAlive
 
@@ -3014,14 +2968,12 @@ class Client(object):
             mid: The message ID
             author_id: The ID of the author
             message: (deprecated. Use ``message_object.text`` instead)
-            message_object: The message (As a `Message` object)
+            message_object (Message): The message (As a `Message` object)
             thread_id: Thread ID that the message was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the message was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the message was sent to. See :ref:`intro_threads`
             ts: The timestamp of the message
             metadata: Extra metadata about the message
             msg: A full set of the data recieved
-        :type message_object: Message
-        :type thread_type: ThreadType
         """
         log.info("{} from {} in {}".format(message_object, thread_id, thread_type.name))
 
@@ -3041,14 +2993,12 @@ class Client(object):
         Args:
             mid: The action ID
             author_id: The ID of the person who changed the color
-            new_color: The new color
+            new_color (ThreadColor): The new color
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type new_color: ThreadColor
-        :type thread_type: ThreadType
         """
         log.info(
             "Color change from {} in {} ({}): {}".format(
@@ -3074,11 +3024,10 @@ class Client(object):
             author_id: The ID of the person who changed the emoji
             new_emoji: The new emoji
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             "Emoji change from {} in {} ({}): {}".format(
@@ -3104,11 +3053,10 @@ class Client(object):
             author_id: The ID of the person who changed the title
             new_title: The new title
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             "Title change from {} in {} ({}): {}".format(
@@ -3133,10 +3081,9 @@ class Client(object):
             author_id: The ID of the person who changed the image
             new_image: The ID of the new image
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info("{} changed thread image in {}".format(author_id, thread_id))
 
@@ -3160,11 +3107,10 @@ class Client(object):
             changed_for: The ID of the person whom got their nickname changed
             new_nickname: The new nickname
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             "Nickname change from {} in {} ({}) for {}: {}".format(
@@ -3256,12 +3202,11 @@ class Client(object):
         Args:
             seen_by: The ID of the person who marked the message as seen
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             seen_ts: A timestamp of when the person saw the message
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             "Messages seen by {} in {} ({}) at {}s".format(
@@ -3285,11 +3230,10 @@ class Client(object):
             msg_ids: The messages that are marked as delivered
             delivered_for: The person that marked the messages as delivered
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             "Messages {} delivered to {} in {} ({}) at {}s".format(
@@ -3309,7 +3253,6 @@ class Client(object):
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             "Marked messages as seen in threads {} at {}s".format(
@@ -3332,10 +3275,9 @@ class Client(object):
             mid: ID of the unsent message
             author_id: The ID of the person who unsent the message
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             "{} unsent the message {} in {} ({}) at {}s".format(
@@ -3416,12 +3358,10 @@ class Client(object):
 
         Args:
             author_id: The ID of the person who sent the action
-            status: The typing status
+            status (TypingStatus): The typing status
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             msg: A full set of the data recieved
-        :type typing_status: TypingStatus
-        :type thread_type: ThreadType
         """
         pass
 
@@ -3449,11 +3389,10 @@ class Client(object):
             score: Score obtained in the game
             leaderboard: Actual leaderboard of the game in the thread
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             '{} played "{}" in {} ({})'.format(
@@ -3475,15 +3414,13 @@ class Client(object):
 
         Args:
             mid: Message ID, that user reacted to
-            reaction: Reaction
+            reaction (MessageReaction): Reaction
             add_reaction: Whether user added or removed reaction
             author_id: The ID of the person who reacted to the message
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             msg: A full set of the data recieved
-        :type reaction: MessageReaction
-        :type thread_type: ThreadType
         """
         log.info(
             "{} reacted to message {} with {} in {} ({})".format(
@@ -3506,10 +3443,9 @@ class Client(object):
             mid: Message ID, that user reacted to
             author_id: The ID of the person who removed reaction
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             "{} removed reaction from {} message in {} ({})".format(
@@ -3525,10 +3461,9 @@ class Client(object):
         Args:
             author_id: The ID of the person who blocked
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             "{} blocked {} ({}) thread".format(author_id, thread_id, thread_type.name)
@@ -3542,10 +3477,9 @@ class Client(object):
         Args:
             author_id: The ID of the person who unblocked
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             "{} unblocked {} ({}) thread".format(author_id, thread_id, thread_type.name)
@@ -3565,14 +3499,12 @@ class Client(object):
 
         Args:
             mid: The action ID
-            location: Sent location info
+            location (LiveLocationAttachment): Sent location info
             author_id: The ID of the person who sent location info
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             msg: A full set of the data recieved
-        :type location: LiveLocationAttachment
-        :type thread_type: ThreadType
         """
         log.info(
             "{} sent live location info in {} ({}) with latitude {} and longitude {}".format(
@@ -3601,11 +3533,10 @@ class Client(object):
             caller_id: The ID of the person who started the call
             is_video_call: True if it's video call
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             "{} started call in {} ({})".format(caller_id, thread_id, thread_type.name)
@@ -3634,11 +3565,10 @@ class Client(object):
             is_video_call: True if it was video call
             call_duration: Call duration in seconds
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             "{} ended call in {} ({})".format(caller_id, thread_id, thread_type.name)
@@ -3662,11 +3592,10 @@ class Client(object):
             joined_id: The ID of the person who joined the call
             is_video_call: True if it's video call
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type thread_type: ThreadType
         """
         log.info(
             "{} joined call in {} ({})".format(joined_id, thread_id, thread_type.name)
@@ -3687,15 +3616,13 @@ class Client(object):
 
         Args:
             mid: The action ID
-            poll: Created poll
+            poll (Poll): Created poll
             author_id: The ID of the person who created the poll
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type poll: Poll
-        :type thread_type: ThreadType
         """
         log.info(
             "{} created poll {} in {} ({})".format(
@@ -3720,15 +3647,13 @@ class Client(object):
 
         Args:
             mid: The action ID
-            poll: Poll, that user voted in
+            poll (Poll): Poll, that user voted in
             author_id: The ID of the person who voted in the poll
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type poll: Poll
-        :type thread_type: ThreadType
         """
         log.info(
             "{} voted in poll {} in {} ({})".format(
@@ -3751,15 +3676,13 @@ class Client(object):
 
         Args:
             mid: The action ID
-            plan: Created plan
+            plan (Plan): Created plan
             author_id: The ID of the person who created the plan
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type plan: Plan
-        :type thread_type: ThreadType
         """
         log.info(
             "{} created plan {} in {} ({})".format(
@@ -3781,14 +3704,12 @@ class Client(object):
 
         Args:
             mid: The action ID
-            plan: Ended plan
+            plan (Plan): Ended plan
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type plan: Plan
-        :type thread_type: ThreadType
         """
         log.info(
             "Plan {} has ended in {} ({})".format(plan, thread_id, thread_type.name)
@@ -3809,15 +3730,13 @@ class Client(object):
 
         Args:
             mid: The action ID
-            plan: Edited plan
+            plan (Plan): Edited plan
             author_id: The ID of the person who edited the plan
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type plan: Plan
-        :type thread_type: ThreadType
         """
         log.info(
             "{} edited plan {} in {} ({})".format(
@@ -3840,15 +3759,13 @@ class Client(object):
 
         Args:
             mid: The action ID
-            plan: Deleted plan
+            plan (Plan): Deleted plan
             author_id: The ID of the person who deleted the plan
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type plan: Plan
-        :type thread_type: ThreadType
         """
         log.info(
             "{} deleted plan {} in {} ({})".format(
@@ -3872,17 +3789,14 @@ class Client(object):
 
         Args:
             mid: The action ID
-            plan: Plan
-            take_part: Whether the person takes part in the plan or not
+            plan (Plan): Plan
+            take_part (bool): Whether the person takes part in the plan or not
             author_id: The ID of the person who will participate in the plan or not
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
-            thread_type: Type of thread that the action was sent to. See :ref:`intro_threads`
+            thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
             msg: A full set of the data recieved
-        :type plan: Plan
-        :type take_part: bool
-        :type thread_type: ThreadType
         """
         if take_part:
             log.info(
@@ -3919,9 +3833,8 @@ class Client(object):
         """Called when the client is listening and client receives information about friend active status.
 
         Args:
-            statuses: Dictionary with user IDs as keys and :class:`ActiveStatus` as values
+            statuses (dict): Dictionary with user IDs as keys and :class:`ActiveStatus` as values
             msg: A full set of the data recieved
-        :type statuses: dict
         """
         log.debug("Buddylist overlay received: {}".format(statuses))
 

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -953,7 +953,7 @@ class Client(object):
 
         url = get_jsmods_require(j, 3)
         if url is None:
-            raise FBchatException("Could not fetch image url from: {}".format(j))
+            raise FBchatException("Could not fetch image URL from: {}".format(j))
         return url
 
     def fetchMessageInfo(self, mid, thread_id=None):

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -171,8 +171,9 @@ class Client(object):
 
         Args:
             queries (dict): Zero or more dictionaries
-        :return: A tuple containing json graphql queries
-        :rtype: tuple
+
+        Returns:
+            tuple: A tuple containing json graphql queries
 
         Raises:
             FBchatException: If request failed
@@ -203,16 +204,16 @@ class Client(object):
     def isLoggedIn(self):
         """Send a request to Facebook to check the login status.
 
-        :return: True if the client is still logged in
-        :rtype: bool
+        Returns:
+            bool: True if the client is still logged in
         """
         return self._state.is_logged_in()
 
     def getSession(self):
         """Retrieve session cookies.
 
-        :return: A dictionay containing session cookies
-        :rtype: dict
+        Returns:
+            dict: A dictionay containing session cookies
         """
         return self._state.get_cookies()
 
@@ -221,8 +222,9 @@ class Client(object):
 
         Args:
             session_cookies (dict): A dictionay containing session cookies
-        :return: False if ``session_cookies`` does not contain proper cookies
-        :rtype: bool
+
+        Returns:
+            bool: False if ``session_cookies`` does not contain proper cookies
         """
         try:
             # Load cookies into current session
@@ -284,8 +286,8 @@ class Client(object):
     def logout(self):
         """Safely log out the client.
 
-        :return: True if the action was successful
-        :rtype: bool
+        Returns:
+            bool: True if the action was successful
         """
         if self._state.logout():
             self._state = None
@@ -304,8 +306,8 @@ class Client(object):
     def _getThread(self, given_thread_id=None, given_thread_type=None):
         """Check if thread ID is given and if default is set, and return correct values.
 
-        :return: Thread ID and thread type
-        :rtype: tuple
+        Returns:
+            tuple: Thread ID and thread type
 
         Raises:
             ValueError: If thread ID is not given and there is no default
@@ -354,8 +356,9 @@ class Client(object):
             before: Fetch only thread before this epoch (in ms) (default all threads)
             after: Fetch only thread after this epoch (in ms) (default all threads)
             limit: The max. amount of threads to fetch (default all threads)
-        :return: :class:`Thread` objects
-        :rtype: list
+
+        Returns:
+            list: :class:`Thread` objects
 
         Raises:
             FBchatException: If request failed
@@ -405,8 +408,9 @@ class Client(object):
 
         Args:
             threads: Thread: List of threads to check for users
-        :return: :class:`User` objects
-        :rtype: list
+
+        Returns:
+            list: :class:`User` objects
 
         Raises:
             FBchatException: If request failed
@@ -431,8 +435,8 @@ class Client(object):
     def fetchAllUsers(self):
         """Fetch all users the client is currently chatting with.
 
-        :return: :class:`User` objects
-        :rtype: list
+        Returns:
+            list: :class:`User` objects
 
         Raises:
             FBchatException: If request failed
@@ -455,8 +459,9 @@ class Client(object):
         Args:
             name: Name of the user
             limit: The max. amount of users to fetch
-        :return: :class:`User` objects, ordered by relevance
-        :rtype: list
+
+        Returns:
+            list: :class:`User` objects, ordered by relevance
 
         Raises:
             FBchatException: If request failed
@@ -471,8 +476,9 @@ class Client(object):
 
         Args:
             name: Name of the page
-        :return: :class:`Page` objects, ordered by relevance
-        :rtype: list
+
+        Returns:
+            list: :class:`Page` objects, ordered by relevance
 
         Raises:
             FBchatException: If request failed
@@ -488,8 +494,9 @@ class Client(object):
         Args:
             name: Name of the group thread
             limit: The max. amount of groups to fetch
-        :return: :class:`Group` objects, ordered by relevance
-        :rtype: list
+
+        Returns:
+            list: :class:`Group` objects, ordered by relevance
 
         Raises:
             FBchatException: If request failed
@@ -505,8 +512,9 @@ class Client(object):
         Args:
             name: Name of the thread
             limit: The max. amount of groups to fetch
-        :return: :class:`User`, :class:`Group` and :class:`Page` objects, ordered by relevance
-        :rtype: list
+
+        Returns:
+            list: :class:`User`, :class:`Group` and :class:`Page` objects, ordered by relevance
 
         Raises:
             FBchatException: If request failed
@@ -541,8 +549,9 @@ class Client(object):
             offset (int): Number of messages to skip
             limit (int): Max. number of messages to retrieve
             thread_id: User/Group ID to search in. See :ref:`intro_threads`
-        :return: Found Message IDs
-        :rtype: typing.Iterable
+
+        Returns:
+            typing.Iterable: Found Message IDs
 
         Raises:
             FBchatException: If request failed
@@ -574,8 +583,9 @@ class Client(object):
             offset (int): Number of messages to skip
             limit (int): Max. number of messages to retrieve
             thread_id: User/Group ID to search in. See :ref:`intro_threads`
-        :return: Found :class:`Message` objects
-        :rtype: typing.Iterable
+
+        Returns:
+            typing.Iterable: Found :class:`Message` objects
 
         Raises:
             FBchatException: If request failed
@@ -594,8 +604,9 @@ class Client(object):
             fetch_messages: Whether to fetch :class:`Message` objects or IDs only
             thread_limit (int): Max. number of threads to retrieve
             message_limit (int): Max. number of messages to retrieve
-        :return: Dictionary with thread IDs as keys and iterables to get messages as values
-        :rtype: typing.Dict[str, typing.Iterable]
+
+        Returns:
+            typing.Dict[str, typing.Iterable]: Dictionary with thread IDs as keys and iterables to get messages as values
 
         Raises:
             FBchatException: If request failed
@@ -662,8 +673,9 @@ class Client(object):
 
         Args:
             user_ids: One or more user ID(s) to query
-        :return: :class:`User` objects, labeled by their ID
-        :rtype: dict
+
+        Returns:
+            dict: :class:`User` objects, labeled by their ID
 
         Raises:
             FBchatException: If request failed
@@ -686,8 +698,9 @@ class Client(object):
 
         Args:
             page_ids: One or more page ID(s) to query
-        :return: :class:`Page` objects, labeled by their ID
-        :rtype: dict
+
+        Returns:
+            dict: :class:`Page` objects, labeled by their ID
 
         Raises:
             FBchatException: If request failed
@@ -707,8 +720,9 @@ class Client(object):
 
         Args:
             group_ids: One or more group ID(s) to query
-        :return: :class:`Group` objects, labeled by their ID
-        :rtype: dict
+
+        Returns:
+            dict: :class:`Group` objects, labeled by their ID
 
         Raises:
             FBchatException: If request failed
@@ -731,8 +745,9 @@ class Client(object):
 
         Args:
             thread_ids: One or more thread ID(s) to query
-        :return: :class:`Thread` objects, labeled by their ID
-        :rtype: dict
+
+        Returns:
+            dict: :class:`Thread` objects, labeled by their ID
 
         Raises:
             FBchatException: If request failed
@@ -796,8 +811,9 @@ class Client(object):
             thread_id: User/Group ID to get messages from. See :ref:`intro_threads`
             limit (int): Max. number of messages to retrieve
             before (int): A timestamp, indicating from which point to retrieve messages
-        :return: :class:`Message` objects
-        :rtype: list
+
+        Returns:
+            list: :class:`Message` objects
 
         Raises:
             FBchatException: If request failed
@@ -841,8 +857,9 @@ class Client(object):
             limit (int): Max. number of threads to retrieve. Capped at 20
             thread_location (ThreadLocation): INBOX, PENDING, ARCHIVED or OTHER
             before (int): A timestamp (in milliseconds), indicating from which point to retrieve threads
-        :return: :class:`Thread` objects
-        :rtype: list
+
+        Returns:
+            list: :class:`Thread` objects
 
         Raises:
             FBchatException: If request failed
@@ -887,8 +904,8 @@ class Client(object):
     def fetchUnread(self):
         """Fetch unread threads.
 
-        :return: List of unread thread ids
-        :rtype: list
+        Returns:
+            list: List of unread thread ids
 
         Raises:
             FBchatException: If request failed
@@ -907,8 +924,8 @@ class Client(object):
     def fetchUnseen(self):
         """Fetch unseen / new threads.
 
-        :return: List of unseen thread ids
-        :rtype: list
+        Returns:
+            list: List of unseen thread ids
 
         Raises:
             FBchatException: If request failed
@@ -923,8 +940,9 @@ class Client(object):
 
         Args:
             image_id (str): The image you want to fethc
-        :return: An url where you can download the original image
-        :rtype: str
+
+        Returns:
+            str: An url where you can download the original image
 
         Raises:
             FBchatException: If request failed
@@ -944,8 +962,9 @@ class Client(object):
         Args:
             mid: Message ID to fetch from
             thread_id: User/Group ID to get message info from. See :ref:`intro_threads`
-        :return: :class:`Message` object
-        :rtype: Message
+
+        Returns:
+            Message: :class:`Message` object
 
         Raises:
             FBchatException: If request failed
@@ -959,7 +978,9 @@ class Client(object):
 
         Args:
             poll_id: Poll ID to fetch from
-        :rtype: list
+
+        Returns:
+            list
 
         Raises:
             FBchatException: If request failed
@@ -973,8 +994,9 @@ class Client(object):
 
         Args:
             plan_id: Plan ID to fetch from
-        :return: :class:`Plan` object
-        :rtype: Plan
+
+        Returns:
+            Plan: :class:`Plan` object
 
         Raises:
             FBchatException: If request failed
@@ -990,8 +1012,8 @@ class Client(object):
     def getPhoneNumbers(self):
         """Fetch list of user's phone numbers.
 
-        :return: List of phone numbers
-        :rtype: list
+        Returns:
+            list: List of phone numbers
         """
         data = self._getPrivateData()
         return [
@@ -1001,8 +1023,8 @@ class Client(object):
     def getEmails(self):
         """Fetch list of user's emails.
 
-        :return: List of emails
-        :rtype: list
+        Returns:
+            list: List of emails
         """
         data = self._getPrivateData()
         return [j["display_email"] for j in data["all_emails"]]
@@ -1017,8 +1039,9 @@ class Client(object):
 
         Args:
             user_id: ID of the user
-        :return: Given user active status
-        :rtype: ActiveStatus
+
+        Returns:
+            ActiveStatus: Given user active status
         """
         return self._buddylist.get(str(user_id))
 
@@ -1027,8 +1050,9 @@ class Client(object):
 
         Args:
             thread_id: ID of the thread
-        :return: :class:`ImageAttachment` or :class:`VideoAttachment`.
-        :rtype: iterable
+
+        Returns:
+            typing.Iterable: :class:`ImageAttachment` or :class:`VideoAttachment`
         """
         thread_id, thread_type = self._getThread(thread_id, None)
         data = {"id": thread_id, "first": 48}
@@ -1173,7 +1197,9 @@ class Client(object):
             message (Message): Message to send
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
-        :return: :ref:`Message ID <intro_message_ids>` of the sent message
+
+        Returns:
+            :ref:`Message ID <intro_message_ids>` of the sent message
 
         Raises:
             FBchatException: If request failed
@@ -1211,7 +1237,9 @@ class Client(object):
             wave_first: Whether to wave first or wave back
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
-        :return: :ref:`Message ID <intro_message_ids>` of the sent message
+
+        Returns:
+            :ref:`Message ID <intro_message_ids>` of the sent message
 
         Raises:
             FBchatException: If request failed
@@ -1235,7 +1263,9 @@ class Client(object):
             payload: Optional answer to the quick reply
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
-        :return: :ref:`Message ID <intro_message_ids>` of the sent message
+
+        Returns:
+            :ref:`Message ID <intro_message_ids>` of the sent message
 
         Raises:
             FBchatException: If request failed
@@ -1296,7 +1326,9 @@ class Client(object):
             message (Message): Additional message
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
-        :return: :ref:`Message ID <intro_message_ids>` of the sent message
+
+        Returns:
+            :ref:`Message ID <intro_message_ids>` of the sent message
 
         Raises:
             FBchatException: If request failed
@@ -1319,7 +1351,9 @@ class Client(object):
             message (Message): Additional message
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
-        :return: :ref:`Message ID <intro_message_ids>` of the sent message
+
+        Returns:
+            :ref:`Message ID <intro_message_ids>` of the sent message
 
         Raises:
             FBchatException: If request failed
@@ -1390,7 +1424,9 @@ class Client(object):
             message: Additional message
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
-        :return: :ref:`Message ID <intro_message_ids>` of the sent files
+
+        Returns:
+            :ref:`Message ID <intro_message_ids>` of the sent files
 
         Raises:
             FBchatException: If request failed
@@ -1411,7 +1447,9 @@ class Client(object):
             message: Additional message
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
-        :return: :ref:`Message ID <intro_message_ids>` of the sent files
+
+        Returns:
+            :ref:`Message ID <intro_message_ids>` of the sent files
 
         Raises:
             FBchatException: If request failed
@@ -1433,7 +1471,9 @@ class Client(object):
             message: Additional message
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
-        :return: :ref:`Message ID <intro_message_ids>` of the sent files
+
+        Returns:
+            :ref:`Message ID <intro_message_ids>` of the sent files
 
         Raises:
             FBchatException: If request failed
@@ -1454,7 +1494,9 @@ class Client(object):
             message: Additional message
             thread_id: User/Group ID to send to. See :ref:`intro_threads`
             thread_type (ThreadType): See :ref:`intro_threads`
-        :return: :ref:`Message ID <intro_message_ids>` of the sent files
+
+        Returns:
+            :ref:`Message ID <intro_message_ids>` of the sent files
 
         Raises:
             FBchatException: If request failed
@@ -1536,7 +1578,9 @@ class Client(object):
         Args:
             message: The initial message
             user_ids: A list of users to create the group with.
-        :return: ID of the new group
+
+        Returns:
+            ID of the new group
 
         Raises:
             FBchatException: If request failed
@@ -2021,7 +2065,9 @@ class Client(object):
         Args:
             thread_id: User/Group ID to which the message belongs. See :ref:`intro_threads`
             message_id: Message ID to set as delivered. See :ref:`intro_threads`
-        :return: True
+
+        Returns:
+            True
 
         Raises:
             FBchatException: If request failed
@@ -2091,7 +2137,9 @@ class Client(object):
 
         Args:
             friend_id: The ID of the friend that you want to remove
-        :return: True
+
+        Returns:
+            True
 
         Raises:
             FBchatException: If request failed
@@ -2105,7 +2153,9 @@ class Client(object):
 
         Args:
             user_id: The ID of the user that you want to block
-        :return: True
+
+        Returns:
+            True
 
         Raises:
             FBchatException: If request failed
@@ -2119,7 +2169,9 @@ class Client(object):
 
         Args:
             user_id: The ID of the user that you want to unblock
-        :return: Whether the request was successful
+
+        Returns:
+            Whether the request was successful
 
         Raises:
             FBchatException: If request failed
@@ -2134,7 +2186,9 @@ class Client(object):
         Args:
             location (ThreadLocation): INBOX, PENDING, ARCHIVED or OTHER
             thread_ids: Thread IDs to move. See :ref:`intro_threads`
-        :return: True
+
+        Returns:
+            True
 
         Raises:
             FBchatException: If request failed
@@ -2168,7 +2222,9 @@ class Client(object):
 
         Args:
             thread_ids: Thread IDs to delete. See :ref:`intro_threads`
-        :return: True
+
+        Returns:
+            True
 
         Raises:
             FBchatException: If request failed
@@ -2193,7 +2249,9 @@ class Client(object):
 
         Args:
             thread_id: User/Group ID to mark as spam. See :ref:`intro_threads`
-        :return: True
+
+        Returns:
+            True
 
         Raises:
             FBchatException: If request failed
@@ -2207,7 +2265,9 @@ class Client(object):
 
         Args:
             message_ids: Message IDs to delete
-        :return: True
+
+        Returns:
+            True
 
         Raises:
             FBchatException: If request failed
@@ -2986,8 +3046,8 @@ class Client(object):
             ``markAlive`` parameter is deprecated, use :func:`Client.setActiveStatus`
             or ``markAlive`` parameter in :func:`Client.listen` instead.
 
-        :return: Whether the loop should keep running
-        :rtype: bool
+        Returns:
+            bool: Whether the loop should keep running
         """
         if markAlive is not None:
             self._markAlive = markAlive
@@ -3084,7 +3144,9 @@ class Client(object):
 
         Args:
             exception: The exception that was encountered
-        :return: Whether the loop should keep running
+
+        Returns:
+            Whether the loop should keep running
         """
         log.exception("Got exception while listening")
         return True

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -575,7 +575,7 @@ class Client(object):
     def searchForMessages(self, query, offset=0, limit=5, thread_id=None):
         """Find and get `Message` objects by query.
 
-        .. warning::
+        Warning:
             This method sends request for every found message ID.
 
         Args:
@@ -668,7 +668,7 @@ class Client(object):
     def fetchUserInfo(self, *user_ids):
         """Fetch users' info from IDs, unordered.
 
-        .. warning::
+        Warning:
             Sends two requests, to fetch all available info!
 
         Args:
@@ -693,7 +693,7 @@ class Client(object):
     def fetchPageInfo(self, *page_ids):
         """Fetch pages' info from IDs, unordered.
 
-        .. warning::
+        Warning:
             Sends two requests, to fetch all available info!
 
         Args:
@@ -740,7 +740,7 @@ class Client(object):
     def fetchThreadInfo(self, *thread_ids):
         """Fetch threads' info from IDs, unordered.
 
-        .. warning::
+        Warning:
             Sends two requests if users or pages are present, to fetch all available info!
 
         Args:
@@ -1034,7 +1034,7 @@ class Client(object):
 
         Return ``None`` if status isn't known.
 
-        .. warning::
+        Warning:
             Only works when listening.
 
         Args:
@@ -1855,7 +1855,7 @@ class Client(object):
     def changeThreadEmoji(self, emoji, thread_id=None):
         """Change thread color.
 
-        .. note::
+        Note:
             While changing the emoji, the Facebook web client actually sends multiple
             different requests, though only this one is required to make the change.
 
@@ -2118,14 +2118,14 @@ class Client(object):
 
     def markAsSeen(self):
         """
-        .. todo::
+        Todo:
             Documenting this
         """
         j = self._payload_post("/ajax/mercury/mark_seen.php", {"seen_timestamp": now()})
 
     def friendConnect(self, friend_id):
         """
-        .. todo::
+        Todo:
             Documenting this
         """
         data = {"to_friend": friend_id, "action": "confirm"}
@@ -3042,7 +3042,7 @@ class Client(object):
 
         This method is useful if you want to control fbchat from an external event loop.
 
-        .. warning::
+        Warning:
             ``markAlive`` parameter is deprecated, use :func:`Client.setActiveStatus`
             or ``markAlive`` parameter in :func:`Client.listen` instead.
 
@@ -3541,7 +3541,7 @@ class Client(object):
 
     def onInbox(self, unseen=None, unread=None, recent_unread=None, msg=None):
         """
-        .. todo::
+        Todo:
             Documenting this
 
         Args:
@@ -3726,7 +3726,7 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody starts a call in a group.
 
-        .. todo::
+        Todo:
             Make this work with private calls.
 
         Args:
@@ -3757,7 +3757,7 @@ class Client(object):
     ):
         """Called when the client is listening, and somebody ends a call in a group.
 
-        .. todo::
+        Todo:
             Make this work with private calls.
 
         Args:

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -44,7 +44,7 @@ class Client(object):
 
     @property
     def ssl_verify(self):
-        """Verify ssl certificate.
+        """Verify SSL certificate.
 
         Set to False to allow debugging with a proxy.
         """
@@ -167,13 +167,13 @@ class Client(object):
             raise FBchatException("Missing payload: {}".format(j))
 
     def graphql_requests(self, *queries):
-        """Execute graphql queries.
+        """Execute GraphQL queries.
 
         Args:
             queries (dict): Zero or more dictionaries
 
         Returns:
-            tuple: A tuple containing json graphql queries
+            tuple: A tuple containing JSON GraphQL queries
 
         Raises:
             FBchatException: If request failed
@@ -213,7 +213,7 @@ class Client(object):
         """Retrieve session cookies.
 
         Returns:
-            dict: A dictionay containing session cookies
+            dict: A dictionary containing session cookies
         """
         return self._state.get_cookies()
 
@@ -221,7 +221,7 @@ class Client(object):
         """Load session cookies.
 
         Args:
-            session_cookies (dict): A dictionay containing session cookies
+            session_cookies (dict): A dictionary containing session cookies
 
         Returns:
             bool: False if ``session_cookies`` does not contain proper cookies
@@ -936,13 +936,13 @@ class Client(object):
         return result["thread_fbids"] + result["other_user_fbids"]
 
     def fetchImageUrl(self, image_id):
-        """Fetch url to download the original image from an image attachment ID.
+        """Fetch URL to download the original image from an image attachment ID.
 
         Args:
-            image_id (str): The image you want to fethc
+            image_id (str): The image you want to fetch
 
         Returns:
-            str: An url where you can download the original image
+            str: An URL where you can download the original image
 
         Raises:
             FBchatException: If request failed
@@ -1658,7 +1658,7 @@ class Client(object):
         j = self._payload_post("/messaging/save_admins/?dpr=1", data)
 
     def addGroupAdmins(self, admin_ids, thread_id=None):
-        """Set specifed users as group admins.
+        """Set specified users as group admins.
 
         Args:
             admin_ids: One or more user IDs to set admin
@@ -1670,7 +1670,7 @@ class Client(object):
         self._adminStatus(admin_ids, True, thread_id)
 
     def removeGroupAdmins(self, admin_ids, thread_id=None):
-        """Remove admin status from specifed users.
+        """Remove admin status from specified users.
 
         Args:
             admin_ids: One or more user IDs to remove admin
@@ -1989,10 +1989,10 @@ class Client(object):
         """
         thread_id, thread_type = self._getThread(thread_id, None)
 
-        # We're using ordered dicts, because the Facebook endpoint that parses the POST
-        # parameters is badly implemented, and deals with ordering the options wrongly.
-        # If you can find a way to fix this for the endpoint, or if you find another
-        # endpoint, please do suggest it ;)
+        # We're using ordered dictionaries, because the Facebook endpoint that parses
+        # the POST parameters is badly implemented, and deals with ordering the options
+        # wrongly. If you can find a way to fix this for the endpoint, or if you find
+        # another endpoint, please do suggest it ;)
         data = OrderedDict([("question_text", poll.title), ("target_id", thread_id)])
 
         for i, option in enumerate(poll.options):
@@ -2133,7 +2133,7 @@ class Client(object):
         j = self._payload_post("/ajax/add_friend/action.php?dpr=1", data)
 
     def removeFriend(self, friend_id=None):
-        """Remove a specifed friend from the client's friend list.
+        """Remove a specified friend from the client's friend list.
 
         Args:
             friend_id: The ID of the friend that you want to remove
@@ -2149,7 +2149,7 @@ class Client(object):
         return True
 
     def blockUser(self, user_id):
-        """Block messages from a specifed user.
+        """Block messages from a specified user.
 
         Args:
             user_id: The ID of the user that you want to block
@@ -2181,7 +2181,7 @@ class Client(object):
         return True
 
     def moveThreads(self, location, thread_ids):
-        """Move threads to specifed location.
+        """Move threads to specified location.
 
         Args:
             location (ThreadLocation): INBOX, PENDING, ARCHIVED or OTHER
@@ -2261,7 +2261,7 @@ class Client(object):
         return True
 
     def deleteMessages(self, message_ids):
-        """Delete specifed messages.
+        """Delete specified messages.
 
         Args:
             message_ids: Message IDs to delete
@@ -3040,7 +3040,8 @@ class Client(object):
     def doOneListen(self, markAlive=None):
         """Do one cycle of the listening loop.
 
-        This method is useful if you want to control fbchat from an external event loop.
+        This method is useful if you want to control the client from an external event
+        loop.
 
         Warning:
             ``markAlive`` parameter is deprecated, use `Client.setActiveStatus`
@@ -3174,7 +3175,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the message was sent to. See :ref:`intro_threads`
             ts: The timestamp of the message
             metadata: Extra metadata about the message
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info("{} from {} in {}".format(message_object, thread_id, thread_type.name))
 
@@ -3199,7 +3200,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "Color change from {} in {} ({}): {}".format(
@@ -3228,7 +3229,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "Emoji change from {} in {} ({}): {}".format(
@@ -3257,7 +3258,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "Title change from {} in {} ({}): {}".format(
@@ -3284,7 +3285,7 @@ class Client(object):
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info("{} changed thread image in {}".format(author_id, thread_id))
 
@@ -3311,7 +3312,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "Nickname change from {} in {} ({}) for {}: {}".format(
@@ -3337,7 +3338,7 @@ class Client(object):
             author_id: The ID of the person who added the admins
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info("{} added admin: {} in {}".format(author_id, added_id, thread_id))
 
@@ -3359,7 +3360,7 @@ class Client(object):
             author_id: The ID of the person who removed the admins
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info("{} removed admin: {} in {}".format(author_id, removed_id, thread_id))
 
@@ -3381,7 +3382,7 @@ class Client(object):
             author_id: The ID of the person who changed approval mode
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         if approval_mode:
             log.info("{} activated approval mode in {}".format(author_id, thread_id))
@@ -3407,7 +3408,7 @@ class Client(object):
             seen_ts: A timestamp of when the person saw the message
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "Messages seen by {} in {} ({}) at {}s".format(
@@ -3434,7 +3435,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "Messages {} delivered to {} in {} ({}) at {}s".format(
@@ -3453,7 +3454,7 @@ class Client(object):
             seen_ts: A timestamp of when the threads were seen
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "Marked messages as seen in threads {} at {}s".format(
@@ -3478,7 +3479,7 @@ class Client(object):
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} unsent the message {} in {} ({}) at {}s".format(
@@ -3503,7 +3504,7 @@ class Client(object):
             author_id: The ID of the person who added the people
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} added: {} in {}".format(author_id, ", ".join(added_ids), thread_id)
@@ -3526,7 +3527,7 @@ class Client(object):
             author_id: The ID of the person who removed the person
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info("{} removed: {} in {}".format(author_id, removed_id, thread_id))
 
@@ -3535,7 +3536,7 @@ class Client(object):
 
         Args:
             from_id: The ID of the person that sent the request
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info("Friend request from {}".format(from_id))
 
@@ -3548,7 +3549,7 @@ class Client(object):
             unseen: --
             unread: --
             recent_unread: --
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info("Inbox event: {}, {}, {}".format(unseen, unread, recent_unread))
 
@@ -3562,7 +3563,7 @@ class Client(object):
             status (TypingStatus): The typing status
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         pass
 
@@ -3588,12 +3589,12 @@ class Client(object):
             game_id: The ID of the game
             game_name: Name of the game
             score: Score obtained in the game
-            leaderboard: Actual leaderboard of the game in the thread
+            leaderboard: Actual leader board of the game in the thread
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             '{} played "{}" in {} ({})'.format(
@@ -3621,7 +3622,7 @@ class Client(object):
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} reacted to message {} with {} in {} ({})".format(
@@ -3646,7 +3647,7 @@ class Client(object):
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} removed reaction from {} message in {} ({})".format(
@@ -3664,7 +3665,7 @@ class Client(object):
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} blocked {} ({}) thread".format(author_id, thread_id, thread_type.name)
@@ -3680,7 +3681,7 @@ class Client(object):
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} unblocked {} ({}) thread".format(author_id, thread_id, thread_type.name)
@@ -3705,7 +3706,7 @@ class Client(object):
             thread_id: Thread ID that the action was sent to. See :ref:`intro_threads`
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} sent live location info in {} ({}) with latitude {} and longitude {}".format(
@@ -3737,7 +3738,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} started call in {} ({})".format(caller_id, thread_id, thread_type.name)
@@ -3769,7 +3770,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} ended call in {} ({})".format(caller_id, thread_id, thread_type.name)
@@ -3796,7 +3797,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} joined call in {} ({})".format(joined_id, thread_id, thread_type.name)
@@ -3823,7 +3824,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} created poll {} in {} ({})".format(
@@ -3854,7 +3855,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} voted in poll {} in {} ({})".format(
@@ -3883,7 +3884,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} created plan {} in {} ({})".format(
@@ -3910,7 +3911,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "Plan {} has ended in {} ({})".format(plan, thread_id, thread_type.name)
@@ -3937,7 +3938,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} edited plan {} in {} ({})".format(
@@ -3966,7 +3967,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.info(
             "{} deleted plan {} in {} ({})".format(
@@ -3997,7 +3998,7 @@ class Client(object):
             thread_type (ThreadType): Type of thread that the action was sent to. See :ref:`intro_threads`
             ts: A timestamp of the action
             metadata: Extra metadata about the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         if take_part:
             log.info(
@@ -4017,7 +4018,7 @@ class Client(object):
 
         Args:
             ts: A timestamp of the action
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         pass
 
@@ -4025,8 +4026,8 @@ class Client(object):
         """Called when the client receives chat online presence update.
 
         Args:
-            buddylist: A list of dicts with friend id and last seen timestamp
-            msg: A full set of the data recieved
+            buddylist: A list of dictionaries with friend id and last seen timestamp
+            msg: A full set of the data received
         """
         log.debug("Chat Timestamps received: {}".format(buddylist))
 
@@ -4035,24 +4036,24 @@ class Client(object):
 
         Args:
             statuses (dict): Dictionary with user IDs as keys and `ActiveStatus` as values
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.debug("Buddylist overlay received: {}".format(statuses))
 
     def onUnknownMesssageType(self, msg=None):
-        """Called when the client is listening, and some unknown data was recieved.
+        """Called when the client is listening, and some unknown data was received.
 
         Args:
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.debug("Unknown message received: {}".format(msg))
 
     def onMessageError(self, exception=None, msg=None):
-        """Called when an error was encountered while parsing recieved data.
+        """Called when an error was encountered while parsing received data.
 
         Args:
             exception: The exception that was encountered
-            msg: A full set of the data recieved
+            msg: A full set of the data received
         """
         log.exception("Exception in parsing of {}".format(msg))
 

--- a/fbchat/_core.py
+++ b/fbchat/_core.py
@@ -8,7 +8,7 @@ log = logging.getLogger("client")
 
 
 class Enum(aenum.Enum):
-    """Used internally by fbchat to support enumerations"""
+    """Used internally by ``fbchat`` to support enumerations"""
 
     def __repr__(self):
         # For documentation:

--- a/fbchat/_exception.py
+++ b/fbchat/_exception.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 
 
 class FBchatException(Exception):
-    """Custom exception thrown by fbchat.
+    """Custom exception thrown by ``fbchat``.
 
-    All exceptions in the fbchat module inherits this.
+    All exceptions in the ``fbchat`` module inherits this.
     """
 
 
@@ -14,7 +14,7 @@ class FBchatFacebookError(FBchatException):
     fb_error_code = None
     #: The error message that Facebook returned (In the user's own language)
     fb_error_message = None
-    #: The status code that was sent in the http response (eg. 404) (Usually only set if not successful, aka. not 200)
+    #: The status code that was sent in the HTTP response (e.g. 404) (Usually only set if not successful, aka. not 200)
     request_status_code = None
 
     def __init__(
@@ -25,7 +25,7 @@ class FBchatFacebookError(FBchatException):
         request_status_code=None,
     ):
         super(FBchatFacebookError, self).__init__(message)
-        """Thrown by fbchat when Facebook returns an error"""
+        """Thrown by ``fbchat`` when Facebook returns an error"""
         self.fb_error_code = str(fb_error_code)
         self.fb_error_message = fb_error_message
         self.request_status_code = request_status_code
@@ -57,4 +57,4 @@ class FBchatPleaseRefresh(FBchatFacebookError):
 
 
 class FBchatUserError(FBchatException):
-    """Thrown by fbchat when wrong values are entered."""
+    """Thrown by ``fbchat`` when wrong values are entered."""

--- a/fbchat/_exception.py
+++ b/fbchat/_exception.py
@@ -3,7 +3,10 @@ from __future__ import unicode_literals
 
 
 class FBchatException(Exception):
-    """Custom exception thrown by fbchat. All exceptions in the fbchat module inherits this"""
+    """Custom exception thrown by fbchat.
+
+    All exceptions in the fbchat module inherits this.
+    """
 
 
 class FBchatFacebookError(FBchatException):
@@ -54,4 +57,4 @@ class FBchatPleaseRefresh(FBchatFacebookError):
 
 
 class FBchatUserError(FBchatException):
-    """Thrown by fbchat when wrong values are entered"""
+    """Thrown by fbchat when wrong values are entered."""

--- a/fbchat/_file.py
+++ b/fbchat/_file.py
@@ -9,7 +9,7 @@ from ._attachment import Attachment
 class FileAttachment(Attachment):
     """Represents a file that has been sent as a Facebook attachment."""
 
-    #: Url where you can download the file
+    #: URL where you can download the file
     url = attr.ib(None)
     #: Size of the file in bytes
     size = attr.ib(None)
@@ -37,9 +37,9 @@ class AudioAttachment(Attachment):
 
     #: Name of the file
     filename = attr.ib(None)
-    #: Url of the audio file
+    #: URL of the audio file
     url = attr.ib(None)
-    #: Duration of the audioclip in milliseconds
+    #: Duration of the audio clip in milliseconds
     duration = attr.ib(None)
     #: Audio type
     audio_type = attr.ib(None)
@@ -61,11 +61,11 @@ class AudioAttachment(Attachment):
 class ImageAttachment(Attachment):
     """Represents an image that has been sent as a Facebook attachment.
 
-    To retrieve the full image url, use: `Client.fetchImageUrl`, and pass it the id of
+    To retrieve the full image URL, use: `Client.fetchImageUrl`, and pass it the id of
     the image attachment.
     """
 
-    #: The extension of the original image (eg. 'png')
+    #: The extension of the original image (e.g. ``png``)
     original_extension = attr.ib(None)
     #: Width of original image
     width = attr.ib(None, converter=lambda x: None if x is None else int(x))
@@ -92,7 +92,7 @@ class ImageAttachment(Attachment):
     #: Height of the large preview image
     large_preview_height = attr.ib(None)
 
-    #: URL to an animated preview of the image (eg. for gifs)
+    #: URL to an animated preview of the image (e.g. for GIFs)
     animated_preview_url = attr.ib(None)
     #: Width of the animated preview image
     animated_preview_width = attr.ib(None)

--- a/fbchat/_file.py
+++ b/fbchat/_file.py
@@ -7,7 +7,7 @@ from ._attachment import Attachment
 
 @attr.s(cmp=False)
 class FileAttachment(Attachment):
-    """Represents a file that has been sent as a Facebook attachment"""
+    """Represents a file that has been sent as a Facebook attachment."""
 
     #: Url where you can download the file
     url = attr.ib(None)
@@ -33,7 +33,7 @@ class FileAttachment(Attachment):
 
 @attr.s(cmp=False)
 class AudioAttachment(Attachment):
-    """Represents an audio file that has been sent as a Facebook attachment"""
+    """Represents an audio file that has been sent as a Facebook attachment."""
 
     #: Name of the file
     filename = attr.ib(None)
@@ -59,10 +59,10 @@ class AudioAttachment(Attachment):
 
 @attr.s(cmp=False, init=False)
 class ImageAttachment(Attachment):
-    """Represents an image that has been sent as a Facebook attachment
+    """Represents an image that has been sent as a Facebook attachment.
 
-    To retrieve the full image url, use: :func:`fbchat.Client.fetchImageUrl`, and pass
-    it the uid of the image attachment
+    To retrieve the full image url, use: `Client.fetchImageUrl`, and pass it the id of
+    the image attachment.
     """
 
     #: The extension of the original image (eg. 'png')
@@ -170,7 +170,7 @@ class ImageAttachment(Attachment):
 
 @attr.s(cmp=False, init=False)
 class VideoAttachment(Attachment):
-    """Represents a video that has been sent as a Facebook attachment"""
+    """Represents a video that has been sent as a Facebook attachment."""
 
     #: Size of the original video in bytes
     size = attr.ib(None)

--- a/fbchat/_group.py
+++ b/fbchat/_group.py
@@ -8,7 +8,7 @@ from ._thread import ThreadType, Thread
 
 @attr.s(cmp=False, init=False)
 class Group(Thread):
-    """Represents a Facebook group. Inherits `Thread`"""
+    """Represents a Facebook group. Inherits `Thread`."""
 
     #: Unique list (set) of the group thread's participant user IDs
     participants = attr.ib(factory=set, converter=lambda x: set() if x is None else x)
@@ -107,7 +107,7 @@ class Group(Thread):
 
 @attr.s(cmp=False, init=False)
 class Room(Group):
-    """Deprecated. Use :class:`Group` instead"""
+    """Deprecated. Use `Group` instead."""
 
     # True is room is not discoverable
     privacy_mode = attr.ib(None)

--- a/fbchat/_group.py
+++ b/fbchat/_group.py
@@ -12,7 +12,7 @@ class Group(Thread):
 
     #: Unique list (set) of the group thread's participant user IDs
     participants = attr.ib(factory=set, converter=lambda x: set() if x is None else x)
-    #: A dict, containing user nicknames mapped to their IDs
+    #: A dictionary, containing user nicknames mapped to their IDs
     nicknames = attr.ib(factory=dict, converter=lambda x: {} if x is None else x)
     #: A :class:`ThreadColor`. The groups's message color
     color = attr.ib(None)

--- a/fbchat/_location.py
+++ b/fbchat/_location.py
@@ -8,9 +8,9 @@ from . import _util
 
 @attr.s(cmp=False)
 class LocationAttachment(Attachment):
-    """Represents a user location
+    """Represents a user location.
 
-    Latitude and longitude OR address is provided by Facebook
+    Latitude and longitude OR address is provided by Facebook.
     """
 
     #: Latitude of the location
@@ -58,7 +58,7 @@ class LocationAttachment(Attachment):
 
 @attr.s(cmp=False, init=False)
 class LiveLocationAttachment(LocationAttachment):
-    """Represents a live user location"""
+    """Represents a live user location."""
 
     #: Name of the location
     name = attr.ib(None)

--- a/fbchat/_message.py
+++ b/fbchat/_message.py
@@ -75,9 +75,9 @@ class Message(object):
     timestamp = attr.ib(None, init=False)
     #: Whether the message is read
     is_read = attr.ib(None, init=False)
-    #: A list of pepole IDs who read the message, works only with :func:`fbchat.Client.fetchThreadMessages`
+    #: A list of people IDs who read the message, works only with :func:`fbchat.Client.fetchThreadMessages`
     read_by = attr.ib(factory=list, init=False)
-    #: A dict with user's IDs as keys, and their :class:`MessageReaction` as values
+    #: A dictionary with user's IDs as keys, and their :class:`MessageReaction` as values
     reactions = attr.ib(factory=dict, init=False)
     #: A :class:`Sticker`
     sticker = attr.ib(None)

--- a/fbchat/_message.py
+++ b/fbchat/_message.py
@@ -9,7 +9,7 @@ from ._core import Enum
 
 
 class EmojiSize(Enum):
-    """Used to specify the size of a sent emoji"""
+    """Used to specify the size of a sent emoji."""
 
     LARGE = "369239383222810"
     MEDIUM = "369239343222814"
@@ -33,7 +33,7 @@ class EmojiSize(Enum):
 
 
 class MessageReaction(Enum):
-    """Used to specify a message reaction"""
+    """Used to specify a message reaction."""
 
     HEART = "❤"
     LOVE = "😍"
@@ -47,7 +47,7 @@ class MessageReaction(Enum):
 
 @attr.s(cmp=False)
 class Mention(object):
-    """Represents a @mention"""
+    """Represents a ``@mention``."""
 
     #: The thread ID the mention is pointing at
     thread_id = attr.ib()
@@ -59,7 +59,7 @@ class Mention(object):
 
 @attr.s(cmp=False)
 class Message(object):
-    """Represents a Facebook message"""
+    """Represents a Facebook message."""
 
     #: The actual message
     text = attr.ib(None)
@@ -98,7 +98,7 @@ class Message(object):
     def formatMentions(cls, text, *args, **kwargs):
         """Like `str.format`, but takes tuples with a thread id and text instead.
 
-        Returns a `Message` object, with the formatted string and relevant mentions.
+        Return a `Message` object, with the formatted string and relevant mentions.
 
         >>> Message.formatMentions("Hey {!r}! My name is {}", ("1234", "Peter"), ("4321", "Michael"))
         <Message (None): "Hey 'Peter'! My name is Michael", mentions=[<Mention 1234: offset=4 length=7>, <Mention 4321: offset=24 length=7>] emoji_size=None attachments=[]>

--- a/fbchat/_page.py
+++ b/fbchat/_page.py
@@ -8,7 +8,7 @@ from ._thread import ThreadType, Thread
 
 @attr.s(cmp=False, init=False)
 class Page(Thread):
-    """Represents a Facebook page. Inherits `Thread`"""
+    """Represents a Facebook page. Inherits `Thread`."""
 
     #: The page's custom url
     url = attr.ib(None)

--- a/fbchat/_page.py
+++ b/fbchat/_page.py
@@ -10,7 +10,7 @@ from ._thread import ThreadType, Thread
 class Page(Thread):
     """Represents a Facebook page. Inherits `Thread`."""
 
-    #: The page's custom url
+    #: The page's custom URL
     url = attr.ib(None)
     #: The name of the page's location city
     city = attr.ib(None)

--- a/fbchat/_plan.py
+++ b/fbchat/_plan.py
@@ -14,7 +14,7 @@ class GuestStatus(Enum):
 
 @attr.s(cmp=False)
 class Plan(object):
-    """Represents a plan"""
+    """Represents a plan."""
 
     #: ID of the plan
     uid = attr.ib(None, init=False)

--- a/fbchat/_plan.py
+++ b/fbchat/_plan.py
@@ -18,7 +18,7 @@ class Plan(object):
 
     #: ID of the plan
     uid = attr.ib(None, init=False)
-    #: Plan time (unix time stamp), only precise down to the minute
+    #: Plan time (timestamp), only precise down to the minute
     time = attr.ib(converter=int)
     #: Plan title
     title = attr.ib()
@@ -28,7 +28,7 @@ class Plan(object):
     location_id = attr.ib(None, converter=lambda x: x or "")
     #: ID of the plan creator
     author_id = attr.ib(None, init=False)
-    #: Dict of `User` IDs mapped to their `GuestStatus`
+    #: Dictionary of `User` IDs mapped to their `GuestStatus`
     guests = attr.ib(None, init=False)
 
     @property

--- a/fbchat/_poll.py
+++ b/fbchat/_poll.py
@@ -6,7 +6,7 @@ import attr
 
 @attr.s(cmp=False)
 class Poll(object):
-    """Represents a poll"""
+    """Represents a poll."""
 
     #: Title of the poll
     title = attr.ib()
@@ -29,7 +29,7 @@ class Poll(object):
 
 @attr.s(cmp=False)
 class PollOption(object):
-    """Represents a poll option"""
+    """Represents a poll option."""
 
     #: Text of the poll option
     text = attr.ib()

--- a/fbchat/_quick_reply.py
+++ b/fbchat/_quick_reply.py
@@ -7,7 +7,7 @@ from ._attachment import Attachment
 
 @attr.s(cmp=False)
 class QuickReply(object):
-    """Represents a quick reply"""
+    """Represents a quick reply."""
 
     #: Payload of the quick reply
     payload = attr.ib(None)
@@ -21,7 +21,7 @@ class QuickReply(object):
 
 @attr.s(cmp=False, init=False)
 class QuickReplyText(QuickReply):
-    """Represents a text quick reply"""
+    """Represents a text quick reply."""
 
     #: Title of the quick reply
     title = attr.ib(None)
@@ -38,7 +38,7 @@ class QuickReplyText(QuickReply):
 
 @attr.s(cmp=False, init=False)
 class QuickReplyLocation(QuickReply):
-    """Represents a location quick reply (Doesn't work on mobile)"""
+    """Represents a location quick reply (Doesn't work on mobile)."""
 
     #: Type of the quick reply
     _type = "location"
@@ -50,7 +50,7 @@ class QuickReplyLocation(QuickReply):
 
 @attr.s(cmp=False, init=False)
 class QuickReplyPhoneNumber(QuickReply):
-    """Represents a phone number quick reply (Doesn't work on mobile)"""
+    """Represents a phone number quick reply (Doesn't work on mobile)."""
 
     #: URL of the quick reply image (optional)
     image_url = attr.ib(None)
@@ -64,7 +64,7 @@ class QuickReplyPhoneNumber(QuickReply):
 
 @attr.s(cmp=False, init=False)
 class QuickReplyEmail(QuickReply):
-    """Represents an email quick reply (Doesn't work on mobile)"""
+    """Represents an email quick reply (Doesn't work on mobile)."""
 
     #: URL of the quick reply image (optional)
     image_url = attr.ib(None)

--- a/fbchat/_sticker.py
+++ b/fbchat/_sticker.py
@@ -21,7 +21,7 @@ class Sticker(Attachment):
     large_sprite_image = attr.ib(None)
     #: The amount of frames present in the spritemap pr. row
     frames_per_row = attr.ib(None)
-    #: The amount of frames present in the spritemap pr. coloumn
+    #: The amount of frames present in the spritemap pr. column
     frames_per_col = attr.ib(None)
     #: The frame rate the spritemap is intended to be played in
     frame_rate = attr.ib(None)

--- a/fbchat/_sticker.py
+++ b/fbchat/_sticker.py
@@ -7,7 +7,7 @@ from ._attachment import Attachment
 
 @attr.s(cmp=False, init=False)
 class Sticker(Attachment):
-    """Represents a Facebook sticker that has been sent to a thread as an attachment"""
+    """Represents a Facebook sticker that has been sent to a thread as an attachment."""
 
     #: The sticker-pack's ID
     pack = attr.ib(None)

--- a/fbchat/_thread.py
+++ b/fbchat/_thread.py
@@ -6,7 +6,10 @@ from ._core import Enum
 
 
 class ThreadType(Enum):
-    """Used to specify what type of Facebook thread is being used. See :ref:`intro_threads` for more info"""
+    """Used to specify what type of Facebook thread is being used.
+
+    See :ref:`intro_threads` for more info.
+    """
 
     USER = 1
     GROUP = 2
@@ -24,7 +27,7 @@ class ThreadLocation(Enum):
 
 
 class ThreadColor(Enum):
-    """Used to specify a thread colors"""
+    """Used to specify a thread colors."""
 
     MESSENGER_BLUE = "#0084ff"
     VIKING = "#44bec7"
@@ -60,7 +63,7 @@ class ThreadColor(Enum):
 
 @attr.s(cmp=False, init=False)
 class Thread(object):
-    """Represents a Facebook thread"""
+    """Represents a Facebook thread."""
 
     #: The unique identifier of the thread. Can be used a ``thread_id``. See :ref:`intro_threads` for more info
     uid = attr.ib(converter=str)

--- a/fbchat/_thread.py
+++ b/fbchat/_thread.py
@@ -69,7 +69,7 @@ class Thread(object):
     uid = attr.ib(converter=str)
     #: Specifies the type of thread. Can be used a ``thread_type``. See :ref:`intro_threads` for more info
     type = attr.ib()
-    #: A url to the thread's picture
+    #: A URL to the thread's picture
     photo = attr.ib(None)
     #: The name of the thread
     name = attr.ib(None)

--- a/fbchat/_user.py
+++ b/fbchat/_user.py
@@ -38,7 +38,7 @@ GENDERS = {
 
 
 class TypingStatus(Enum):
-    """Used to specify whether the user is typing or has stopped typing"""
+    """Used to specify whether the user is typing or has stopped typing."""
 
     STOPPED = 0
     TYPING = 1
@@ -46,7 +46,7 @@ class TypingStatus(Enum):
 
 @attr.s(cmp=False, init=False)
 class User(Thread):
-    """Represents a Facebook user. Inherits `Thread`"""
+    """Represents a Facebook user. Inherits `Thread`."""
 
     #: The profile url
     url = attr.ib(None)

--- a/fbchat/_user.py
+++ b/fbchat/_user.py
@@ -48,7 +48,7 @@ class TypingStatus(Enum):
 class User(Thread):
     """Represents a Facebook user. Inherits `Thread`."""
 
-    #: The profile url
+    #: The profile URL
     url = attr.ib(None)
     #: The users first name
     first_name = attr.ib(None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ test = [
 ]
 docs = [
     "sphinx~=2.0",
+    "sphinxcontrib-spelling~=4.0"
 ]
 lint = [
     "black",


### PR DESCRIPTION
- Use [Google docstring style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
- Fix docstring spelling mistakes (using [sphinxcontrib-spelling](https://sphinxcontrib-spelling.readthedocs.io/))
- Various other documentation fixes

When reviewing, it's recommended that you skip reviewing the commits that convert to the Google docstring style (they were done mostly with simple `grep`s).