### PR TITLE
Move requests into state

### DIFF
--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -1305,30 +1305,7 @@ class Client(object):
         )
 
     def _upload(self, files, voice_clip=False):
-        """Upload files to Facebook.
-
-        `files` should be a list of files that requests can upload, see
-        `requests.request <https://docs.python-requests.org/en/master/api/#requests.request>`_.
-
-        Return a list of tuples with a file's ID and mimetype.
-        """
-        file_dict = {"upload_{}".format(i): f for i, f in enumerate(files)}
-
-        data = {"voice_clip": voice_clip}
-
-        j = self._payload_post(
-            "https://upload.facebook.com/ajax/mercury/upload.php", data, files=file_dict
-        )
-
-        if len(j["metadata"]) != len(files):
-            raise FBchatException(
-                "Some files could not be uploaded: {}, {}".format(j, files)
-            )
-
-        return [
-            (data[mimetype_to_key(data["filetype"])], data["filetype"])
-            for data in j["metadata"]
-        ]
+        return self._state._upload(files, voice_clip=voice_clip)
 
     def _sendFiles(
         self, files, message=None, thread_id=None, thread_type=ThreadType.USER

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -1056,30 +1056,11 @@ class Client(object):
 
     def _doSendRequest(self, data, get_thread_id=False):
         """Send the data to `SendURL`, and returns the message ID or None on failure."""
-        j = self._post("/messaging/send/", data)
-
-        # update JS token if received in response
-        fb_dtsg = get_jsmods_require(j, 2)
-        if fb_dtsg is not None:
-            self._state.fb_dtsg = fb_dtsg
-
-        try:
-            message_ids = [
-                (action["message_id"], action["thread_fbid"])
-                for action in j["payload"]["actions"]
-                if "message_id" in action
-            ]
-            if len(message_ids) != 1:
-                log.warning("Got multiple message ids' back: {}".format(message_ids))
-            if get_thread_id:
-                return message_ids[0]
-            else:
-                return message_ids[0][0]
-        except (KeyError, IndexError, TypeError) as e:
-            raise FBchatException(
-                "Error when sending message: "
-                "No message IDs could be found: {}".format(j)
-            )
+        mid, thread_id = self._state._do_send_request(data)
+        if get_thread_id:
+            return mid, thread_id
+        else:
+            return mid
 
     def send(self, message, thread_id=None, thread_type=ThreadType.USER):
         """Send message to a thread.

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -111,8 +111,8 @@ class Client(object):
     def _get(self, url, params):
         return self._state._get(url, params)
 
-    def _post(self, url, params, files=None, as_graphql=False):
-        return self._state._post(url, params, files=files, as_graphql=as_graphql)
+    def _post(self, url, params, files=None):
+        return self._state._post(url, params, files=files)
 
     def _payload_post(self, url, data, files=None):
         return self._state._payload_post(url, data, files=files)
@@ -129,12 +129,7 @@ class Client(object):
         Raises:
             FBchatException: If request failed
         """
-        data = {
-            "method": "GET",
-            "response_format": "json",
-            "queries": _graphql.queries_to_json(*queries),
-        }
-        return tuple(self._post("/api/graphqlbatch/", data, as_graphql=True))
+        return tuple(self._state._graphql_requests(*queries))
 
     def graphql_request(self, query):
         """Shorthand for ``graphql_requests(query)[0]``.

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -111,30 +111,8 @@ class Client(object):
     def _get(self, url, params):
         return self._state._get(url, params)
 
-    def _post(self, url, data, files=None, as_graphql=False, error_retries=3):
-        data.update(self._state.get_params())
-        r = self._state._session.post(prefix_url(url), data=data, files=files)
-        content = check_request(r)
-        try:
-            if as_graphql:
-                return _graphql.response_to_json(content)
-            else:
-                j = to_json(content)
-                # TODO: Remove this, and move it to _payload_post instead
-                # We can't yet, since errors raised in here need to be caught below
-                handle_payload_error(j)
-                return j
-        except FBchatPleaseRefresh:
-            if error_retries > 0:
-                self._state._do_refresh()
-                return self._post(
-                    url,
-                    data,
-                    files=files,
-                    as_graphql=as_graphql,
-                    error_retries=error_retries - 1,
-                )
-            raise
+    def _post(self, url, params, files=None, as_graphql=False):
+        return self._state._post(url, params, files=files, as_graphql=as_graphql)
 
     def _payload_post(self, url, data, files=None):
         j = self._post(url, data, files=files)

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -115,11 +115,7 @@ class Client(object):
         return self._state._post(url, params, files=files, as_graphql=as_graphql)
 
     def _payload_post(self, url, data, files=None):
-        j = self._post(url, data, files=files)
-        try:
-            return j["payload"]
-        except (KeyError, TypeError):
-            raise FBchatException("Missing payload: {}".format(j))
+        return self._state._payload_post(url, data, files=files)
 
     def graphql_requests(self, *queries):
         """Execute GraphQL queries.

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -108,19 +108,8 @@ class Client(object):
     INTERNAL REQUEST METHODS
     """
 
-    def _get(self, url, params, error_retries=3):
-        params.update(self._state.get_params())
-        r = self._state._session.get(prefix_url(url), params=params)
-        content = check_request(r)
-        j = to_json(content)
-        try:
-            handle_payload_error(j)
-        except FBchatPleaseRefresh:
-            if error_retries > 0:
-                self._state._do_refresh()
-                return self._get(url, params, error_retries=error_retries - 1)
-            raise
-        return j
+    def _get(self, url, params):
+        return self._state._get(url, params)
 
     def _post(self, url, data, files=None, as_graphql=False, error_retries=3):
         data.update(self._state.get_params())

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -87,7 +87,6 @@ class Client(object):
         """
         self._sticky, self._pool = (None, None)
         self._seq = "0"
-        self._client_id = hex(int(random() * 2 ** 31))[2:]
         self._default_thread_id = None
         self._default_thread_type = None
         self._pull_channel = 0
@@ -1043,7 +1042,7 @@ class Client(object):
             "source": "source:chat:web",
             "offline_threading_id": messageAndOTID,
             "message_id": messageAndOTID,
-            "threading_id": generateMessageID(self._client_id),
+            "threading_id": generateMessageID(self._state._client_id),
             "ephemeral_ttl_mode:": "0",
         }
 
@@ -2261,7 +2260,7 @@ class Client(object):
         data = {
             "seq": self._seq,
             "channel": "p_" + self._uid,
-            "clientid": self._client_id,
+            "clientid": self._state._client_id,
             "partition": -2,
             "cap": 0,
             "uid": self._uid,
@@ -2282,7 +2281,7 @@ class Client(object):
             "msgs_recv": 0,
             "sticky_token": self._sticky,
             "sticky_pool": self._pool,
-            "clientid": self._client_id,
+            "clientid": self._state._client_id,
             "state": "active" if self._markAlive else "offline",
         }
         return self._get(

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -108,12 +108,6 @@ class Client(object):
     INTERNAL REQUEST METHODS
     """
 
-    def _do_refresh(self):
-        # TODO: Raise the error instead, and make the user do the refresh manually
-        # It may be a bad idea to do this in an exception handler, if you have a better method, please suggest it!
-        log.warning("Refreshing state and resending request")
-        self._state = State.from_session(session=self._state._session)
-
     def _get(self, url, params, error_retries=3):
         params.update(self._state.get_params())
         r = self._state._session.get(prefix_url(url), params=params)
@@ -123,7 +117,7 @@ class Client(object):
             handle_payload_error(j)
         except FBchatPleaseRefresh:
             if error_retries > 0:
-                self._do_refresh()
+                self._state._do_refresh()
                 return self._get(url, params, error_retries=error_retries - 1)
             raise
         return j
@@ -143,7 +137,7 @@ class Client(object):
                 return j
         except FBchatPleaseRefresh:
             if error_retries > 0:
-                self._do_refresh()
+                self._state._do_refresh()
                 return self._post(
                     url,
                     data,

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -1032,19 +1032,7 @@ class Client(object):
         return message if isinstance(message, Message) else Message(text=message)
 
     def _getSendData(self, thread_id=None, thread_type=ThreadType.USER):
-        """Return the data needed to send a request to `SendURL`."""
-        messageAndOTID = generateOfflineThreadingID()
-        timestamp = now()
-        data = {
-            "client": "mercury",
-            "author": "fbid:{}".format(self._uid),
-            "timestamp": timestamp,
-            "source": "source:chat:web",
-            "offline_threading_id": messageAndOTID,
-            "message_id": messageAndOTID,
-            "threading_id": generateMessageID(self._state._client_id),
-            "ephemeral_ttl_mode:": "0",
-        }
+        data = {}
 
         # Set recipient
         if thread_type in [ThreadType.USER, ThreadType.PAGE]:

--- a/fbchat/_group.py
+++ b/fbchat/_group.py
@@ -104,6 +104,9 @@ class Group(Thread):
             plan=plan,
         )
 
+    def _to_send_data(self):
+        return {"thread_fbid": self.uid}
+
 
 @attr.s(cmp=False, init=False)
 class Room(Group):

--- a/fbchat/_state.py
+++ b/fbchat/_state.py
@@ -240,3 +240,10 @@ class State(object):
                     error_retries=error_retries - 1,
                 )
             raise
+
+    def _payload_post(self, url, data, files=None):
+        j = self._post(url, data, files=files)
+        try:
+            return j["payload"]
+        except (KeyError, TypeError):
+            raise _exception.FBchatException("Missing payload: {}".format(j))

--- a/fbchat/_state.py
+++ b/fbchat/_state.py
@@ -191,3 +191,13 @@ class State(object):
         session = session_factory(user_agent=user_agent)
         session.cookies = requests.cookies.merge_cookies(session.cookies, cookies)
         return cls.from_session(session=session)
+
+    def _do_refresh(self):
+        # TODO: Raise the error instead, and make the user do the refresh manually
+        # It may be a bad idea to do this in an exception handler, if you have a better method, please suggest it!
+        _util.log.warning("Refreshing state and resending request")
+        new = State.from_session(session=self._session)
+        self.fb_dtsg = new.fb_dtsg
+        self._revision = new._revision
+        self._counter = new._counter
+        self._logout_h = new._logout_h or self._logout_h

--- a/fbchat/_state.py
+++ b/fbchat/_state.py
@@ -104,7 +104,7 @@ class State(object):
     """Stores and manages state required for most Facebook requests."""
 
     user_id = attr.ib()
-    fb_dtsg = attr.ib()
+    _fb_dtsg = attr.ib()
     _revision = attr.ib()
     _session = attr.ib(factory=session_factory)
     _counter = attr.ib(0)
@@ -117,7 +117,7 @@ class State(object):
             "__a": 1,
             "__req": _util.str_base(self._counter, 36),
             "__rev": self._revision,
-            "fb_dtsg": self.fb_dtsg,
+            "fb_dtsg": self._fb_dtsg,
         }
 
     @classmethod
@@ -213,7 +213,7 @@ class State(object):
         _util.log.warning("Refreshing state and resending request")
         new = State.from_session(session=self._session)
         self.user_id = new.user_id
-        self.fb_dtsg = new.fb_dtsg
+        self._fb_dtsg = new._fb_dtsg
         self._revision = new._revision
         self._counter = new._counter
         self._logout_h = new._logout_h or self._logout_h
@@ -304,7 +304,7 @@ class State(object):
         # update JS token if received in response
         fb_dtsg = _util.get_jsmods_require(j, 2)
         if fb_dtsg is not None:
-            self.fb_dtsg = fb_dtsg
+            self._fb_dtsg = fb_dtsg
 
         try:
             message_ids = [

--- a/fbchat/_state.py
+++ b/fbchat/_state.py
@@ -247,3 +247,11 @@ class State(object):
             return j["payload"]
         except (KeyError, TypeError):
             raise _exception.FBchatException("Missing payload: {}".format(j))
+
+    def _graphql_requests(self, *queries):
+        data = {
+            "method": "GET",
+            "response_format": "json",
+            "queries": _graphql.queries_to_json(*queries),
+        }
+        return self._post("/api/graphqlbatch/", data, as_graphql=True)

--- a/fbchat/_state.py
+++ b/fbchat/_state.py
@@ -32,6 +32,10 @@ def session_factory(user_agent=None):
     return session
 
 
+def client_id_factory():
+    return hex(int(random.random() * 2 ** 31))[2:]
+
+
 def is_home(url):
     parts = _util.urlparse(url)
     # Check the urls `/home.php` and `/`
@@ -104,6 +108,7 @@ class State(object):
     _revision = attr.ib()
     _session = attr.ib(factory=session_factory)
     _counter = attr.ib(0)
+    _client_id = attr.ib(factory=client_id_factory)
     _logout_h = attr.ib(None)
 
     def get_params(self):

--- a/fbchat/_state.py
+++ b/fbchat/_state.py
@@ -266,3 +266,29 @@ class State(object):
             "queries": _graphql.queries_to_json(*queries),
         }
         return self._post("/api/graphqlbatch/", data, as_graphql=True)
+
+    def _upload(self, files, voice_clip=False):
+        """Upload files to Facebook.
+
+        `files` should be a list of files that requests can upload, see
+        `requests.request <https://docs.python-requests.org/en/master/api/#requests.request>`_.
+
+        Return a list of tuples with a file's ID and mimetype.
+        """
+        file_dict = {"upload_{}".format(i): f for i, f in enumerate(files)}
+
+        data = {"voice_clip": voice_clip}
+
+        j = self._payload_post(
+            "https://upload.facebook.com/ajax/mercury/upload.php", data, files=file_dict
+        )
+
+        if len(j["metadata"]) != len(files):
+            raise _exception.FBchatException(
+                "Some files could not be uploaded: {}, {}".format(j, files)
+            )
+
+        return [
+            (data[_util.mimetype_to_key(data["filetype"])], data["filetype"])
+            for data in j["metadata"]
+        ]

--- a/fbchat/_state.py
+++ b/fbchat/_state.py
@@ -299,6 +299,15 @@ class State(object):
         ]
 
     def _do_send_request(self, data):
+        offline_threading_id = _util.generateOfflineThreadingID()
+        data["client"] = "mercury"
+        data["author"] = "fbid:{}".format(self.user_id)
+        data["timestamp"] = _util.now()
+        data["source"] = "source:chat:web"
+        data["offline_threading_id"] = offline_threading_id
+        data["message_id"] = offline_threading_id
+        data["threading_id"] = _util.generateMessageID(self._client_id)
+        data["ephemeral_ttl_mode:"] = "0"
         j = self._post("/messaging/send/", data)
 
         # update JS token if received in response

--- a/fbchat/_thread.py
+++ b/fbchat/_thread.py
@@ -141,3 +141,7 @@ class Thread(object):
                 else:
                     rtn["own_nickname"] = pc[1].get("nickname")
         return rtn
+
+    def _to_send_data(self):
+        # TODO: Only implement this in subclasses
+        return {"other_user_fbid": self.uid}

--- a/fbchat/_thread.py
+++ b/fbchat/_thread.py
@@ -16,6 +16,17 @@ class ThreadType(Enum):
     ROOM = 2
     PAGE = 3
 
+    def _to_class(self):
+        """Convert this enum value to the corresponding class."""
+        from . import _user, _group, _page
+
+        return {
+            ThreadType.USER: _user.User,
+            ThreadType.GROUP: _group.Group,
+            ThreadType.ROOM: _group.Room,
+            ThreadType.PAGE: _page.Page,
+        }[self]
+
 
 class ThreadLocation(Enum):
     """Used to specify where a thread is located (inbox, pending, archived, other)."""


### PR DESCRIPTION
Move various request helpers (e.g. `Client._post`) into the `State` model. This is done so that we can slowly start moving implementations into the relevant models (instead of having them live in `Client`).

For example, the implementation for `Client.addUsersToGroup` could, and should, be moved to `Group.add_users`. ~(However, before we can do this, a bit more work is required on updating `._getSendData` and `._doSendRequest`)~

This PR should be fairly trivial to review, one commit at a time.