### PR TITLE
Add a optional timestamp parameter to mark_as_read and mark_as_unread

### DIFF
--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -1722,41 +1722,46 @@ class Client:
         j = self._payload_post("/ajax/mercury/delivery_receipts.php", data)
         return True
 
-    def _read_status(self, read, thread_ids):
+    def _read_status(self, read, thread_ids, timestamp=None):
         thread_ids = _util.require_list(thread_ids)
 
-        data = {"watermarkTimestamp": _util.now(), "shouldSendReadReceipt": "true"}
+        data = {
+            "watermarkTimestamp": timestamp or _util.now(),
+            "shouldSendReadReceipt": "true",
+        }
 
         for thread_id in thread_ids:
             data["ids[{}]".format(thread_id)] = "true" if read else "false"
 
         j = self._payload_post("/ajax/mercury/change_read_status.php", data)
 
-    def mark_as_read(self, thread_ids=None):
+    def mark_as_read(self, thread_ids=None, timestamp=None):
         """Mark threads as read.
 
         All messages inside the specified threads will be marked as read.
 
         Args:
             thread_ids: User/Group IDs to set as read. See :ref:`intro_threads`
+            timestamp: Timestamp to signal the read cursor at, in milliseconds, default is now()
 
         Raises:
             FBchatException: If request failed
         """
-        self._read_status(True, thread_ids)
+        self._read_status(True, thread_ids, timestamp)
 
-    def mark_as_unread(self, thread_ids=None):
+    def mark_as_unread(self, thread_ids=None, timestamp=None):
         """Mark threads as unread.
 
         All messages inside the specified threads will be marked as unread.
 
         Args:
             thread_ids: User/Group IDs to set as unread. See :ref:`intro_threads`
+            timestamp: Timestamp to signal the read cursor at, in milliseconds, default is now()
 
         Raises:
             FBchatException: If request failed
         """
-        self._read_status(False, thread_ids)
+        self._read_status(False, thread_ids, timestamp)
 
     def mark_as_seen(self):
         """

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -1726,7 +1726,9 @@ class Client:
         thread_ids = _util.require_list(thread_ids)
 
         data = {
-            "watermarkTimestamp": timestamp or _util.now(),
+            "watermarkTimestamp": _util.datetime_to_millis(timestamp)
+            if timestamp
+            else _util.now(),
             "shouldSendReadReceipt": "true",
         }
 
@@ -1742,7 +1744,7 @@ class Client:
 
         Args:
             thread_ids: User/Group IDs to set as read. See :ref:`intro_threads`
-            timestamp: Timestamp to signal the read cursor at, in milliseconds, default is now()
+            timestamp: Timestamp (as a Datetime) to signal the read cursor at, default is the current time
 
         Raises:
             FBchatException: If request failed
@@ -1756,7 +1758,7 @@ class Client:
 
         Args:
             thread_ids: User/Group IDs to set as unread. See :ref:`intro_threads`
-            timestamp: Timestamp to signal the read cursor at, in milliseconds, default is now()
+            timestamp: Timestamp (as a Datetime) to signal the read cursor at, default is the current time
 
         Raises:
             FBchatException: If request failed


### PR DESCRIPTION
Currently `mark_as_read()` and `mark_as_unread()` call now() to determine the read timestamp to push to Facebook.

This can create a race condition if:

* Caller read message m1
* Caller calls `mark_as_read()`
* In the meantime, another message, m2 is received in the same thread
* `_read_status()` gets its timestamp calling `now()`, which is after `m2.timestamp` , but m2 hasn't been read yet
* As a result, m2 is marked as read while it hasn't been

This change adds an optional `timestamp` argument to `mark_as_read()` and `mark_as_unread()` to solve this issue (the caller *should* set this argument to the timestamp of the last message that been read)