### PR TITLE
Add WebSocket/MQTT support

### DIFF
--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -2231,6 +2231,12 @@ class Client(object):
                 msg=delta,
             )
 
+        elif delta_class == "MarkFolderSeen":
+            locations = [
+                ThreadLocation(folder.lstrip("FOLDER_")) for folder in delta["folders"]
+            ]
+            self._onSeen(locations=locations, ts=delta["timestamp"], msg=delta)
+
         # Emoji change
         elif delta_type == "change_thread_icon":
             new_emoji = delta["untypedData"]["thread_icon"]
@@ -2741,6 +2747,8 @@ class Client(object):
             )
 
         # Typing
+        # /thread_typing {'sender_fbid': X, 'state': 1, 'type': 'typ', 'thread': 'Y'}
+        # /orca_typing_notifications {'type': 'typ', 'sender_fbid': X, 'state': 0}
         elif topic in ("/thread_typing", "/orca_typing_notifications"):
             author_id = str(m["sender_fbid"])
             thread_id = m.get("thread", author_id)
@@ -2755,13 +2763,6 @@ class Client(object):
                 thread_type=thread_type,
                 msg=m,
             )
-
-        # Delivered
-
-        # Seen
-        # elif mtype == "m_read_receipt":
-        #
-        #     self.onSeen(m.get('realtime_viewer_fbid'), m.get('reader'), m.get('time'))
 
         elif topic == "jewel_requests_add":
             from_id = m["from"]
@@ -3298,6 +3299,17 @@ class Client(object):
             msg: A full set of the data received
         """
         log.info("Friend request from {}".format(from_id))
+
+    def _onSeen(self, locations=None, ts=None, msg=None):
+        """
+        Todo:
+            Document this, and make it public
+
+        Args:
+            locations: ---
+            ts: A timestamp of the action
+            msg: A full set of the data received
+        """
 
     def onInbox(self, unseen=None, unread=None, recent_unread=None, msg=None):
         """

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -2741,19 +2741,13 @@ class Client(object):
             )
 
         # Typing
-        elif topic in ["typ", "ttyp"]:
-            author_id = str(m.get("from"))
-            thread_id = m.get("thread_fbid")
-            if thread_id:
-                thread_type = ThreadType.GROUP
-                thread_id = str(thread_id)
-            else:
-                thread_type = ThreadType.USER
-                if author_id == self._uid:
-                    thread_id = m.get("to")
-                else:
-                    thread_id = author_id
-            typing_status = TypingStatus(m.get("st"))
+        elif topic in ("/thread_typing", "/orca_typing_notifications"):
+            author_id = str(m["sender_fbid"])
+            thread_id = m.get("thread", author_id)
+            typing_status = TypingStatus(m.get("state"))
+            thread_type = (
+                ThreadType.USER if thread_id == author_id else ThreadType.GROUP
+            )
             self.onTyping(
                 author_id=author_id,
                 status=typing_status,

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -2437,6 +2437,10 @@ class Client(object):
                 msg=delta,
             )
 
+        # Skip "no operation" events
+        elif delta_class == "NoOp":
+            pass
+
         # Group call started/ended
         elif delta_type == "rtc_call_log":
             thread_id, thread_type = getThreadIdAndThreadType(metadata)

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -2834,10 +2834,13 @@ class Client(object):
 
     def stopListening(self):
         """Stop the listening loop."""
-        if not self._mqtt:
-            raise ValueError("Not listening")
-        self._mqtt.disconnect()
         self.listening = False
+        if not self._mqtt:
+            return
+        self._mqtt.disconnect()
+        # TODO: Preserve the _mqtt object
+        # Currently, there's some issues when disconnecting
+        self._mqtt = None
 
     def listen(self, markAlive=None):
         """Initialize and runs the listening loop continually.

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -2168,7 +2168,7 @@ class Client(object):
     LISTEN METHODS
     """
 
-    def _parseDelta(self, m):
+    def _parseDelta(self, delta):
         def getThreadIdAndThreadType(msg_metadata):
             """Return a tuple consisting of thread ID and thread type."""
             id_thread = None
@@ -2181,7 +2181,6 @@ class Client(object):
                 type_thread = ThreadType.USER
             return id_thread, type_thread
 
-        delta = m["delta"]
         delta_type = delta.get("type")
         delta_class = delta.get("class")
         metadata = delta.get("messageMetadata")
@@ -2201,7 +2200,7 @@ class Client(object):
                 author_id=author_id,
                 thread_id=thread_id,
                 ts=ts,
-                msg=m,
+                msg=delta,
             )
 
         # Left/removed participants
@@ -2214,7 +2213,7 @@ class Client(object):
                 author_id=author_id,
                 thread_id=thread_id,
                 ts=ts,
-                msg=m,
+                msg=delta,
             )
 
         # Color change
@@ -2229,7 +2228,7 @@ class Client(object):
                 thread_type=thread_type,
                 ts=ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Emoji change
@@ -2244,7 +2243,7 @@ class Client(object):
                 thread_type=thread_type,
                 ts=ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Thread title change
@@ -2259,14 +2258,14 @@ class Client(object):
                 thread_type=thread_type,
                 ts=ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Forced fetch
         elif delta_class == "ForcedFetch":
             mid = delta.get("messageId")
             if mid is None:
-                self.onUnknownMesssageType(msg=m)
+                self.onUnknownMesssageType(msg=delta)
             else:
                 thread_id = str(delta["threadKey"]["threadFbId"])
                 fetch_info = self._forcedFetch(thread_id, mid)
@@ -2288,7 +2287,7 @@ class Client(object):
                         thread_id=thread_id,
                         thread_type=ThreadType.GROUP,
                         ts=ts,
-                        msg=m,
+                        msg=delta,
                     )
 
         # Nickname change
@@ -2305,7 +2304,7 @@ class Client(object):
                 thread_type=thread_type,
                 ts=ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Admin added or removed in a group thread
@@ -2321,7 +2320,7 @@ class Client(object):
                     thread_id=thread_id,
                     thread_type=thread_type,
                     ts=ts,
-                    msg=m,
+                    msg=delta,
                 )
             elif admin_event == "remove_admin":
                 self.onAdminRemoved(
@@ -2331,7 +2330,7 @@ class Client(object):
                     thread_id=thread_id,
                     thread_type=thread_type,
                     ts=ts,
-                    msg=m,
+                    msg=delta,
                 )
 
         # Group approval mode change
@@ -2345,7 +2344,7 @@ class Client(object):
                 thread_id=thread_id,
                 thread_type=thread_type,
                 ts=ts,
-                msg=m,
+                msg=delta,
             )
 
         # Message delivered
@@ -2363,7 +2362,7 @@ class Client(object):
                 thread_type=thread_type,
                 ts=ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Message seen
@@ -2379,7 +2378,7 @@ class Client(object):
                 seen_ts=seen_ts,
                 ts=delivered_ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Messages marked as seen
@@ -2400,7 +2399,11 @@ class Client(object):
 
             # thread_id, thread_type = getThreadIdAndThreadType(delta)
             self.onMarkedSeen(
-                threads=threads, seen_ts=seen_ts, ts=delivered_ts, metadata=delta, msg=m
+                threads=threads,
+                seen_ts=seen_ts,
+                ts=delivered_ts,
+                metadata=delta,
+                msg=delta,
             )
 
         # Game played
@@ -2425,7 +2428,7 @@ class Client(object):
                 thread_type=thread_type,
                 ts=ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Group call started/ended
@@ -2443,7 +2446,7 @@ class Client(object):
                     thread_type=thread_type,
                     ts=ts,
                     metadata=metadata,
-                    msg=m,
+                    msg=delta,
                 )
             elif call_status == "call_ended":
                 self.onCallEnded(
@@ -2455,7 +2458,7 @@ class Client(object):
                     thread_type=thread_type,
                     ts=ts,
                     metadata=metadata,
-                    msg=m,
+                    msg=delta,
                 )
 
         # User joined to group call
@@ -2470,7 +2473,7 @@ class Client(object):
                 thread_type=thread_type,
                 ts=ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Group poll event
@@ -2489,7 +2492,7 @@ class Client(object):
                     thread_type=thread_type,
                     ts=ts,
                     metadata=metadata,
-                    msg=m,
+                    msg=delta,
                 )
             elif event_type == "update_vote":
                 # User voted on group poll
@@ -2505,7 +2508,7 @@ class Client(object):
                     thread_type=thread_type,
                     ts=ts,
                     metadata=metadata,
-                    msg=m,
+                    msg=delta,
                 )
 
         # Plan created
@@ -2519,7 +2522,7 @@ class Client(object):
                 thread_type=thread_type,
                 ts=ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Plan ended
@@ -2532,7 +2535,7 @@ class Client(object):
                 thread_type=thread_type,
                 ts=ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Plan edited
@@ -2546,7 +2549,7 @@ class Client(object):
                 thread_type=thread_type,
                 ts=ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Plan deleted
@@ -2560,7 +2563,7 @@ class Client(object):
                 thread_type=thread_type,
                 ts=ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Plan participation change
@@ -2576,13 +2579,13 @@ class Client(object):
                 thread_type=thread_type,
                 ts=ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Client payload (that weird numbers)
         elif delta_class == "ClientPayload":
             payload = json.loads("".join(chr(z) for z in delta["payload"]))
-            ts = m.get("ofd_ts")
+            ts = now()  # Hack
             for d in payload.get("deltas", []):
 
                 # Message reaction
@@ -2603,7 +2606,7 @@ class Client(object):
                             thread_id=thread_id,
                             thread_type=thread_type,
                             ts=ts,
-                            msg=m,
+                            msg=delta,
                         )
                     else:
                         self.onReactionRemoved(
@@ -2612,7 +2615,7 @@ class Client(object):
                             thread_id=thread_id,
                             thread_type=thread_type,
                             ts=ts,
-                            msg=m,
+                            msg=delta,
                         )
 
                 # Viewer status change
@@ -2629,7 +2632,7 @@ class Client(object):
                                 thread_id=thread_id,
                                 thread_type=thread_type,
                                 ts=ts,
-                                msg=m,
+                                msg=delta,
                             )
                         else:
                             self.onBlock(
@@ -2637,7 +2640,7 @@ class Client(object):
                                 thread_id=thread_id,
                                 thread_type=thread_type,
                                 ts=ts,
-                                msg=m,
+                                msg=delta,
                             )
 
                 # Live location info
@@ -2655,7 +2658,7 @@ class Client(object):
                             thread_id=thread_id,
                             thread_type=thread_type,
                             ts=ts,
-                            msg=m,
+                            msg=delta,
                         )
 
                 # Message deletion
@@ -2671,7 +2674,7 @@ class Client(object):
                         thread_id=thread_id,
                         thread_type=thread_type,
                         ts=ts,
-                        msg=m,
+                        msg=delta,
                     )
 
                 elif d.get("deltaMessageReply"):
@@ -2690,7 +2693,7 @@ class Client(object):
                         thread_type=thread_type,
                         ts=message.timestamp,
                         metadata=metadata,
-                        msg=m,
+                        msg=delta,
                     )
 
         # New message
@@ -2711,17 +2714,20 @@ class Client(object):
                 thread_type=thread_type,
                 ts=ts,
                 metadata=metadata,
-                msg=m,
+                msg=delta,
             )
 
         # Unknown message type
         else:
-            self.onUnknownMesssageType(msg=m)
+            self.onUnknownMesssageType(msg=delta)
 
     def _parse_payload(self, topic, m):
         # Things that directly change chat
-        if topic == "delta":
-            self._parseDelta(m)
+        if topic == "/t_ms":
+            if "deltas" not in m:
+                return
+            for delta in m["deltas"]:
+                self._parseDelta(delta)
 
         # TODO: Remove old parsing below
 

--- a/fbchat/_mqtt.py
+++ b/fbchat/_mqtt.py
@@ -11,7 +11,7 @@ def generate_session_id():
 
 
 @attr.s(slots=True)
-class Mqtt:
+class Mqtt(object):
     _state = attr.ib()
     _mqtt = attr.ib()
     _on_message = attr.ib()
@@ -62,7 +62,7 @@ class Mqtt:
             OSError,
             paho.mqtt.client.WebsocketConnectionError,
         ) as e:
-            raise _exception.FBchatException("MQTT connection failed") from e
+            raise _exception.FBchatException("MQTT connection failed")
 
         # Raise error if connecting failed
         if rc != paho.mqtt.client.MQTT_ERR_SUCCESS:

--- a/fbchat/_mqtt.py
+++ b/fbchat/_mqtt.py
@@ -1,0 +1,108 @@
+import attr
+import random
+import paho.mqtt.client
+from . import _util, _graphql
+
+
+@attr.s(slots=True)
+class Mqtt:
+    _state = attr.ib()
+    _mqtt = attr.ib()
+
+    @classmethod
+    def connect(cls, state, foreground):
+        mqtt = paho.mqtt.client.Client(
+            client_id="mqttwsclient",
+            clean_session=True,
+            protocol=paho.mqtt.client.MQTTv31,
+            transport="websockets",
+        )
+        mqtt.enable_logger()
+
+        # Generate a random session ID between 1 and 9007199254740991
+        session_id = random.randint(1, 2 ** 53)
+
+        username = {
+            # The user ID
+            "u": state.user_id,
+            # Session ID
+            "s": session_id,
+            # Active status setting
+            "chat_on": True,
+            # foreground_state - Whether the window is focused
+            "fg": foreground,
+            # Can be any random ID
+            "d": state._client_id,
+            # Application ID, taken from facebook.com
+            "aid": 219994525426954,
+            # MQTT extension by FB, allows making a SUBSCRIBE while CONNECTing
+            "st": [
+                # TODO: Investigate the result from these
+                # "/inbox",
+                # "/mercury",
+                # "/messaging_events",
+                # "/orca_message_notifications",
+                # "/pp",
+                # "/t_p",
+                # "/t_rtc",
+                # "/webrtc_response",
+                "/legacy_web",
+                "/webrtc",
+                "/onevc",
+                # Things that happen in chats (e.g. messages)
+                "/t_ms",
+                # Group typing notifications
+                "/thread_typing",
+                # Private chat typing notifications
+                "/orca_typing_notifications",
+                "/notify_disconnect",
+                # Active notifications
+                "/orca_presence",
+                "/br_sr",
+                "/sr_res",
+            ],
+            # MQTT extension by FB, allows making a PUBLISH while CONNECTing
+            "pm": [],
+            # Unknown parameters
+            "cp": 3,
+            "ecp": 10,
+            "ct": "websocket",
+            "mqtt_sid": "",
+            "dc": "",
+            "no_auto_fg": True,
+            "gas": None,
+            "pack": [],
+        }
+        mqtt.username_pw_set(_util.json_minimal(username))
+
+        headers = {
+            "Cookie": _util.get_cookie_header(state._session, "edge-chat.facebook.com"),
+            "User-Agent": state._session.headers["User-Agent"],
+            "Origin": "https://www.facebook.com",
+            "Host": "edge-chat.facebook.com",
+        }
+
+        # TODO: Is region (lla | atn | odn | others?) important?
+        mqtt.ws_set_options(path="/chat?sid={}".format(session_id), headers=headers)
+        mqtt.tls_set()
+        response_code = mqtt.connect("edge-chat.facebook.com", 443, keepalive=10)
+        # TODO: Handle response code
+
+        return cls(state=state, mqtt=mqtt)
+
+    def listen(self, on_message):
+        def real_on_message(client, userdata, message):
+            on_message(message.topic, message.payload)
+
+        self._mqtt.on_message = real_on_message
+
+        self._mqtt.loop_forever()  # TODO: retry_first_connection=True?
+
+    def disconnect(self):
+        self._mqtt.disconnect()
+
+    def set_foreground(self, state):
+        payload = _util.json_minimal({"foreground": state})
+        info = self._mqtt.publish("/foreground_state", payload=payload, qos=1)
+        # TODO: We can't wait for this, since the loop is running with .loop_forever()
+        # info.wait_for_publish()

--- a/fbchat/_mqtt.py
+++ b/fbchat/_mqtt.py
@@ -91,6 +91,12 @@ class Mqtt:
             if "lastIssuedSeqId" in j:
                 self._sequence_id = j["lastIssuedSeqId"]
 
+            if "errorCode" in j:
+                # Known types: ERROR_QUEUE_OVERFLOW | ERROR_QUEUE_NOT_FOUND
+                # 'F\xfa\x84\x8c\x85\xf8\xbc-\x88 FB_PAGES_INSUFFICIENT_PERMISSION\x00'
+                log.error("MQTT error code %s received", j["errorCode"])
+                # TODO: Consider resetting the sync_token and sequence ID here?
+
         log.debug("MQTT payload: %s", j)
 
         # Call the external callback

--- a/fbchat/_mqtt.py
+++ b/fbchat/_mqtt.py
@@ -22,46 +22,70 @@ def fetch_sequence_id(state):
         raise
 
 
+HOST = "edge-chat.facebook.com"
+
+
 @attr.s(slots=True)
 class Mqtt:
     _state = attr.ib()
     _mqtt = attr.ib()
+    _session_id = attr.ib()
 
-    @classmethod
-    def connect(cls, state, foreground):
-        mqtt = paho.mqtt.client.Client(
+    def __init__(self, state):
+        self._state = state
+
+        # Generate a random session ID between 1 and 9007199254740991
+        self._session_id = random.randint(1, 2 ** 53)
+
+        self._mqtt = paho.mqtt.client.Client(
             client_id="mqttwsclient",
             clean_session=True,
             protocol=paho.mqtt.client.MQTTv31,
             transport="websockets",
         )
-        mqtt.enable_logger()
+        self._mqtt.enable_logger()
+        # self._mqtt.max_inflight_messages_set(20)
+        # self._mqtt.max_queued_messages_set(0) # unlimited
+        # self._mqtt.message_retry_set(5)
+        # self._mqtt.reconnect_delay_set(min_delay=1, max_delay=1)
 
-        # Generate a random session ID between 1 and 9007199254740991
-        session_id = random.randint(1, 2 ** 53)
-        last_seq_id = fetch_sequence_id(state)
+        # TODO: Is region (lla | atn | odn | others?) important?
+        self._mqtt.ws_set_options(
+            path="/chat?sid={}".format(self._session_id), headers=self._create_headers
+        )
+        self._mqtt.tls_set()
+
+    def _create_headers(self, headers):
+        headers["Cookie"] = _util.get_cookie_header(self._state._session, HOST)
+        headers["User-Agent"] = self._state._session.headers["User-Agent"]
+        headers["Origin"] = "https://www.facebook.com"
+        headers["Host"] = HOST
+        return headers
+
+    def connect(self, foreground):
+        last_seq_id = fetch_sequence_id(self._state)
 
         messenger_sync_create_queue_payload = {
             "sync_api_version": 10,
             "max_deltas_able_to_process": 1000,
             "delta_batch_size": 500,
             "encoding": "JSON",
-            "entity_fbid": state.user_id,
+            "entity_fbid": self._state.user_id,
             "initial_titan_sequence_id": str(last_seq_id),
             "device_params": None,
         }
 
         username = {
             # The user ID
-            "u": state.user_id,
+            "u": self._state.user_id,
             # Session ID
-            "s": session_id,
+            "s": self._session_id,
             # Active status setting
             "chat_on": True,
             # foreground_state - Whether the window is focused
             "fg": foreground,
             # Can be any random ID
-            "d": state._client_id,
+            "d": self._state._client_id,
             # Application ID, taken from facebook.com
             "aid": 219994525426954,
             # MQTT extension by FB, allows making a SUBSCRIBE while CONNECTing
@@ -115,22 +139,10 @@ class Mqtt:
             "gas": None,
             "pack": [],
         }
-        mqtt.username_pw_set(_util.json_minimal(username))
+        self._mqtt.username_pw_set(_util.json_minimal(username))
 
-        headers = {
-            "Cookie": _util.get_cookie_header(state._session, "edge-chat.facebook.com"),
-            "User-Agent": state._session.headers["User-Agent"],
-            "Origin": "https://www.facebook.com",
-            "Host": "edge-chat.facebook.com",
-        }
-
-        # TODO: Is region (lla | atn | odn | others?) important?
-        mqtt.ws_set_options(path="/chat?sid={}".format(session_id), headers=headers)
-        mqtt.tls_set()
-        response_code = mqtt.connect("edge-chat.facebook.com", 443, keepalive=10)
+        response_code = self._mqtt.connect(HOST, 443, keepalive=10)
         # TODO: Handle response code
-
-        return cls(state=state, mqtt=mqtt)
 
     def listen(self, on_message):
         def real_on_message(client, userdata, message):

--- a/fbchat/_mqtt.py
+++ b/fbchat/_mqtt.py
@@ -2,7 +2,7 @@ import attr
 import random
 import paho.mqtt.client
 from ._core import log
-from . import _util, _graphql
+from . import _util, _exception, _graphql
 
 
 def generate_session_id():
@@ -17,7 +17,7 @@ class Mqtt:
     _on_message = attr.ib()
     _chat_on = attr.ib()
     _foreground = attr.ib()
-    _session_id = attr.ib(factory=generate_session_id)
+    _sequence_id = attr.ib()
     _sync_token = attr.ib(None)
 
     _HOST = "edge-chat.facebook.com"
@@ -30,15 +30,6 @@ class Mqtt:
             protocol=paho.mqtt.client.MQTTv31,
             transport="websockets",
         )
-
-        self = cls(
-            state=state,
-            mqtt=mqtt,
-            on_message=on_message,
-            chat_on=chat_on,
-            foreground=foreground,
-        )
-
         mqtt.enable_logger()
         # mqtt.max_inflight_messages_set(20)
         # mqtt.max_queued_messages_set(0)  # unlimited
@@ -46,46 +37,46 @@ class Mqtt:
         # mqtt.reconnect_delay_set(min_delay=1, max_delay=120)
         # TODO: Is region (lla | atn | odn | others?) important?
         mqtt.tls_set()
-        mqtt.ws_set_options(
-            path="/chat?sid={}".format(session_id), headers=self._create_headers
-        )
-        mqtt.on_message = self._on_message_handler
 
-        sequence_id = self._fetch_sequence_id(self._state)
-        # Set connect/reconnect data with an empty sync token and an newly fetched
-        # sequence id initially
-        self._set_reconnect_data(self._sync_token, sequence_id)
+        self = cls(
+            state=state,
+            mqtt=mqtt,
+            on_message=on_message,
+            chat_on=chat_on,
+            foreground=foreground,
+            sequence_id=cls._fetch_sequence_id(state),
+        )
+
+        # Configure callbacks
+        mqtt.on_message = self._on_message_handler
+        mqtt.on_connect = self._on_connect_handler
+
+        self._configure_connect_options()
 
         # TODO: Handle response code
         response_code = mqtt.connect(self._HOST, 443, keepalive=10)
 
-    def _create_headers(self, headers):
-        log.debug("Fetching MQTT headers")
-        # TODO: Make this access thread safe
-        headers["Cookie"] = _util.get_cookie_header(self._state._session, self._HOST)
-        headers["User-Agent"] = self._state._session.headers["User-Agent"]
-        headers["Origin"] = "https://www.facebook.com"
-        headers["Host"] = self._HOST
-        return headers
+        return self
 
     def _on_message_handler(self, client, userdata, message):
-        j = _util.parse_json(message.payload)
-        if message.topic == "/t_ms":
-            sequence_id = None
+        # Parse payload JSON
+        try:
+            j = _util.parse_json(message.payload)
+        except _exception.FBchatFacebookError:
+            log.exception("Failed parsing MQTT data as JSON: %r", message.payload)
+            return
 
+        if message.topic == "/t_ms":
             # Update sync_token when received
             # This is received in the first message after we've created a messenger
             # sync queue.
             if "syncToken" in j and "firstDeltaSeqId" in j:
                 self._sync_token = j["syncToken"]
-                sequence_id = j["firstDeltaSeqId"]
+                self._sequence_id = j["firstDeltaSeqId"]
 
             # Update last sequence id when received
             if "lastIssuedSeqId" in j:
-                sequence_id = j["lastIssuedSeqId"]
-
-            if sequence_id is not None:
-                self._set_reconnect_data(self._sync_token, sequence_id)
+                self._sequence_id = j["lastIssuedSeqId"]
 
         # Call the external callback
         self._on_message(message.topic, j)
@@ -109,40 +100,39 @@ class Mqtt:
             # TODO: Proper exceptions
             raise
 
-    @staticmethod
-    def _get_messenger_sync(state, sync_token, sequence_id):
-        """Get the data to configure receiving messages."""
+    def _on_connect_handler(self, client, userdata, flags, rc):
+        # configure receiving messages.
         payload = {
             "sync_api_version": 10,
             "max_deltas_able_to_process": 1000,
             "delta_batch_size": 500,
             "encoding": "JSON",
-            "entity_fbid": state.user_id,
+            "entity_fbid": self._state.user_id,
         }
 
         # If we don't have a sync_token, create a new messenger queue
         # This is done so that across reconnects, if we've received a sync token, we
         # SHOULD receive a piece of data in /t_ms exactly once!
-        if sync_token is None:
+        if self._sync_token is None:
             topic = "/messenger_sync_create_queue"
-            payload["initial_titan_sequence_id"] = str(sequence_id)
+            payload["initial_titan_sequence_id"] = str(self._sequence_id)
             payload["device_params"] = None
         else:
             topic = "/messenger_sync_get_diffs"
-            payload["last_seq_id"] = str(sequence_id)
-            payload["sync_token"] = sync_token
+            payload["last_seq_id"] = str(self._sequence_id)
+            payload["sync_token"] = self._sync_token
 
-        return topic, payload
+        self._mqtt.publish(topic, _util.json_minimal(payload), qos=1)
 
-    def _set_reconnect_data(self, sync_token, sequence_id):
-        log.debug("Setting MQTT reconnect data: %s/%s", sync_token, sequence_id)
-        topic, payload = self._get_messenger_sync(self._state, sync_token, sequence_id)
+    def _configure_connect_options(self):
+        # Generate a new session ID on each reconnect
+        session_id = generate_session_id()
 
         username = {
             # The user ID
             "u": self._state.user_id,
             # Session ID
-            "s": self._session_id,
+            "s": session_id,
             # Active status setting
             "chat_on": self._chat_on,
             # foreground_state - Whether the window is focused
@@ -178,18 +168,18 @@ class Mqtt:
                 "/sr_res",
             ],
             # MQTT extension by FB, allows making a PUBLISH while CONNECTing
+            # Using this is more efficient, but the same can be acheived with:
+            #     def on_connect(*args):
+            #         mqtt.publish(topic, payload, qos=1)
+            #     mqtt.on_connect = on_connect
+            # TODO: For some reason this doesn't work!
             "pm": [
-                {
-                    "topic": topic,
-                    "payload": _util.json_minimal(payload),
-                    "qos": 1,
-                    "messageId": 65536,
-                }
-                # The above is more efficient, but the same effect could have been
-                # acheived with:
-                #     def on_connect(*args):
-                #         mqtt.publish(topic, payload=..., qos=1)
-                #     mqtt.on_connect = on_connect
+                # {
+                #     "topic": topic,
+                #     "payload": payload,
+                #     "qos": 1,
+                #     "messageId": 65536,
+                # }
             ],
             # Unknown parameters
             "cp": 3,
@@ -205,8 +195,44 @@ class Mqtt:
         # TODO: Make this thread safe
         self._mqtt.username_pw_set(_util.json_minimal(username))
 
+        headers = {
+            # TODO: Make this access thread safe
+            "Cookie": _util.get_cookie_header(self._state._session, self._HOST),
+            "User-Agent": self._state._session.headers["User-Agent"],
+            "Origin": "https://www.facebook.com",
+            "Host": self._HOST,
+        }
+
+        self._mqtt.ws_set_options(
+            path="/chat?sid={}".format(session_id), headers=headers
+        )
+
     def listen(self):
-        self._mqtt.loop_forever()  # TODO: retry_first_connection=True?
+        while True:
+            rc = self._mqtt.loop(timeout=1.0)
+            if rc == paho.mqtt.client.MQTT_ERR_SUCCESS:
+                continue  # No errors
+
+            # If disconnect() has been called
+            if self._mqtt._state == paho.mqtt.client.mqtt_cs_disconnecting:
+                break
+
+            # Wait before reconnecting
+            self._mqtt._reconnect_wait()
+
+            # Try reconnecting
+            self._configure_connect_options()
+            try:
+                self._mqtt.reconnect()
+            except (
+                # Taken from .loop_forever
+                paho.mqtt.client.socket.error,
+                OSError,
+                paho.mqtt.client.WebsocketConnectionError,
+            ):
+                log.debug("MQTT connection failed")
+
+        # self._mqtt.loop_forever()  # TODO: retry_first_connection=True?
 
     def disconnect(self):
         self._mqtt.disconnect()

--- a/fbchat/_mqtt.py
+++ b/fbchat/_mqtt.py
@@ -97,7 +97,7 @@ class Mqtt(object):
                 log.error("MQTT error code %s received", j["errorCode"])
                 # TODO: Consider resetting the sync_token and sequence ID here?
 
-        log.debug("MQTT payload: %s", j)
+        log.debug("MQTT payload: %s, %s", message.topic, j)
 
         # Call the external callback
         self._on_message(message.topic, j)
@@ -149,6 +149,40 @@ class Mqtt(object):
         # Generate a new session ID on each reconnect
         session_id = generate_session_id()
 
+        topics = [
+            # Things that happen in chats (e.g. messages)
+            "/t_ms",
+            # Group typing notifications
+            "/thread_typing",
+            # Private chat typing notifications
+            "/orca_typing_notifications",
+            # Active notifications
+            "/orca_presence",
+            # Other notifications not related to chats (e.g. friend requests)
+            "/legacy_web",
+            # Facebook's continuous error reporting/logging?
+            "/br_sr",
+            # Response to /br_sr
+            "/sr_res",
+            # TODO: Investigate the response from this! (A bunch of binary data)
+            # "/t_p",
+            # TODO: Find out what this does!
+            "/webrtc",
+            # TODO: Find out what this does!
+            "/onevc",
+            # TODO: Find out what this does!
+            "/notify_disconnect",
+            # Old, no longer active topics
+            # These are here just in case something interesting pops up
+            "/inbox",
+            "/mercury",
+            "/messaging_events",
+            "/orca_message_notifications",
+            "/pp",
+            "/t_rtc",
+            "/webrtc_response",
+        ]
+
         username = {
             # The user ID
             "u": self._state.user_id,
@@ -163,31 +197,7 @@ class Mqtt(object):
             # Application ID, taken from facebook.com
             "aid": 219994525426954,
             # MQTT extension by FB, allows making a SUBSCRIBE while CONNECTing
-            "st": [
-                # TODO: Investigate the result from these
-                # "/inbox",
-                # "/mercury",
-                # "/messaging_events",
-                # "/orca_message_notifications",
-                # "/pp",
-                # "/t_p",
-                # "/t_rtc",
-                # "/webrtc_response",
-                "/legacy_web",
-                "/webrtc",
-                "/onevc",
-                # Things that happen in chats (e.g. messages)
-                "/t_ms",
-                # Group typing notifications
-                "/thread_typing",
-                # Private chat typing notifications
-                "/orca_typing_notifications",
-                "/notify_disconnect",
-                # Active notifications
-                "/orca_presence",
-                "/br_sr",
-                "/sr_res",
-            ],
+            "st": topics,
             # MQTT extension by FB, allows making a PUBLISH while CONNECTing
             # Using this is more efficient, but the same can be acheived with:
             #     def on_connect(*args):
@@ -290,3 +300,6 @@ class Mqtt(object):
     # def send_additional_contacts(self, additional_contacts):
     #     payload = _util.json_minimal({"additional_contacts": additional_contacts})
     #     info = self._mqtt.publish("/send_additional_contacts", payload=payload, qos=1)
+    #
+    # def browser_close(self):
+    #     info = self._mqtt.publish("/browser_close", payload=b"{}", qos=1)

--- a/fbchat/_mqtt.py
+++ b/fbchat/_mqtt.py
@@ -1,79 +1,142 @@
 import attr
 import random
 import paho.mqtt.client
+from ._core import log
 from . import _util, _graphql
 
 
-def fetch_sequence_id(state):
-    """Fetch sequence ID."""
-    params = {
-        "limit": 1,
-        "tags": ["INBOX"],
-        "before": None,
-        "includeDeliveryReceipts": False,
-        "includeSeqID": True,
-    }
-    # Same request as in `Client.fetchThreadList`
-    (j,) = state._graphql_requests(_graphql.from_doc_id("1349387578499440", params))
-    try:
-        return int(j["viewer"]["message_threads"]["sync_sequence_id"])
-    except (KeyError, ValueError):
-        # TODO: Proper exceptions
-        raise
-
-
-HOST = "edge-chat.facebook.com"
+def generate_session_id():
+    """Generate a random session ID between 1 and 9007199254740991."""
+    return random.randint(1, 2 ** 53)
 
 
 @attr.s(slots=True)
 class Mqtt:
     _state = attr.ib()
     _mqtt = attr.ib()
-    _session_id = attr.ib()
+    _on_message = attr.ib()
+    _chat_on = attr.ib()
+    _foreground = attr.ib()
+    _session_id = attr.ib(factory=generate_session_id)
+    _sync_token = attr.ib(None)
 
-    def __init__(self, state):
-        self._state = state
+    _HOST = "edge-chat.facebook.com"
 
-        # Generate a random session ID between 1 and 9007199254740991
-        self._session_id = random.randint(1, 2 ** 53)
-
-        self._mqtt = paho.mqtt.client.Client(
+    @classmethod
+    def connect(cls, state, on_message, chat_on, foreground):
+        mqtt = paho.mqtt.client.Client(
             client_id="mqttwsclient",
             clean_session=True,
             protocol=paho.mqtt.client.MQTTv31,
             transport="websockets",
         )
-        self._mqtt.enable_logger()
-        # self._mqtt.max_inflight_messages_set(20)
-        # self._mqtt.max_queued_messages_set(0) # unlimited
-        # self._mqtt.message_retry_set(5)
-        # self._mqtt.reconnect_delay_set(min_delay=1, max_delay=1)
 
-        # TODO: Is region (lla | atn | odn | others?) important?
-        self._mqtt.ws_set_options(
-            path="/chat?sid={}".format(self._session_id), headers=self._create_headers
+        self = cls(
+            state=state,
+            mqtt=mqtt,
+            on_message=on_message,
+            chat_on=chat_on,
+            foreground=foreground,
         )
-        self._mqtt.tls_set()
+
+        mqtt.enable_logger()
+        # mqtt.max_inflight_messages_set(20)
+        # mqtt.max_queued_messages_set(0)  # unlimited
+        # mqtt.message_retry_set(5)
+        # mqtt.reconnect_delay_set(min_delay=1, max_delay=120)
+        # TODO: Is region (lla | atn | odn | others?) important?
+        mqtt.tls_set()
+        mqtt.ws_set_options(
+            path="/chat?sid={}".format(session_id), headers=self._create_headers
+        )
+        mqtt.on_message = self._on_message_handler
+
+        sequence_id = self._fetch_sequence_id(self._state)
+        # Set connect/reconnect data with an empty sync token and an newly fetched
+        # sequence id initially
+        self._set_reconnect_data(self._sync_token, sequence_id)
+
+        # TODO: Handle response code
+        response_code = mqtt.connect(self._HOST, 443, keepalive=10)
 
     def _create_headers(self, headers):
-        headers["Cookie"] = _util.get_cookie_header(self._state._session, HOST)
+        log.debug("Fetching MQTT headers")
+        # TODO: Make this access thread safe
+        headers["Cookie"] = _util.get_cookie_header(self._state._session, self._HOST)
         headers["User-Agent"] = self._state._session.headers["User-Agent"]
         headers["Origin"] = "https://www.facebook.com"
-        headers["Host"] = HOST
+        headers["Host"] = self._HOST
         return headers
 
-    def connect(self, foreground):
-        last_seq_id = fetch_sequence_id(self._state)
+    def _on_message_handler(self, client, userdata, message):
+        j = _util.parse_json(message.payload)
+        if message.topic == "/t_ms":
+            sequence_id = None
 
-        messenger_sync_create_queue_payload = {
+            # Update sync_token when received
+            # This is received in the first message after we've created a messenger
+            # sync queue.
+            if "syncToken" in j and "firstDeltaSeqId" in j:
+                self._sync_token = j["syncToken"]
+                sequence_id = j["firstDeltaSeqId"]
+
+            # Update last sequence id when received
+            if "lastIssuedSeqId" in j:
+                sequence_id = j["lastIssuedSeqId"]
+
+            if sequence_id is not None:
+                self._set_reconnect_data(self._sync_token, sequence_id)
+
+        # Call the external callback
+        self._on_message(message.topic, j)
+
+    @staticmethod
+    def _fetch_sequence_id(state):
+        """Fetch sequence ID."""
+        params = {
+            "limit": 1,
+            "tags": ["INBOX"],
+            "before": None,
+            "includeDeliveryReceipts": False,
+            "includeSeqID": True,
+        }
+        log.debug("Fetching MQTT sequence ID")
+        # Same request as in `Client.fetchThreadList`
+        (j,) = state._graphql_requests(_graphql.from_doc_id("1349387578499440", params))
+        try:
+            return int(j["viewer"]["message_threads"]["sync_sequence_id"])
+        except (KeyError, ValueError):
+            # TODO: Proper exceptions
+            raise
+
+    @staticmethod
+    def _get_messenger_sync(state, sync_token, sequence_id):
+        """Get the data to configure receiving messages."""
+        payload = {
             "sync_api_version": 10,
             "max_deltas_able_to_process": 1000,
             "delta_batch_size": 500,
             "encoding": "JSON",
-            "entity_fbid": self._state.user_id,
-            "initial_titan_sequence_id": str(last_seq_id),
-            "device_params": None,
+            "entity_fbid": state.user_id,
         }
+
+        # If we don't have a sync_token, create a new messenger queue
+        # This is done so that across reconnects, if we've received a sync token, we
+        # SHOULD receive a piece of data in /t_ms exactly once!
+        if sync_token is None:
+            topic = "/messenger_sync_create_queue"
+            payload["initial_titan_sequence_id"] = str(sequence_id)
+            payload["device_params"] = None
+        else:
+            topic = "/messenger_sync_get_diffs"
+            payload["last_seq_id"] = str(sequence_id)
+            payload["sync_token"] = sync_token
+
+        return topic, payload
+
+    def _set_reconnect_data(self, sync_token, sequence_id):
+        log.debug("Setting MQTT reconnect data: %s/%s", sync_token, sequence_id)
+        topic, payload = self._get_messenger_sync(self._state, sync_token, sequence_id)
 
         username = {
             # The user ID
@@ -81,9 +144,9 @@ class Mqtt:
             # Session ID
             "s": self._session_id,
             # Active status setting
-            "chat_on": True,
+            "chat_on": self._chat_on,
             # foreground_state - Whether the window is focused
-            "fg": foreground,
+            "fg": self._foreground,
             # Can be any random ID
             "d": self._state._client_id,
             # Application ID, taken from facebook.com
@@ -116,17 +179,16 @@ class Mqtt:
             ],
             # MQTT extension by FB, allows making a PUBLISH while CONNECTing
             "pm": [
-                # This is required to actually receive messages
                 {
-                    "topic": "/messenger_sync_create_queue",
-                    "payload": _util.json_minimal(messenger_sync_create_queue_payload),
+                    "topic": topic,
+                    "payload": _util.json_minimal(payload),
                     "qos": 1,
                     "messageId": 65536,
                 }
                 # The above is more efficient, but the same effect could have been
                 # acheived with:
                 #     def on_connect(*args):
-                #         mqtt.publish("/messenger_sync_create_queue", ..., qos=1)
+                #         mqtt.publish(topic, payload=..., qos=1)
                 #     mqtt.on_connect = on_connect
             ],
             # Unknown parameters
@@ -139,24 +201,28 @@ class Mqtt:
             "gas": None,
             "pack": [],
         }
+
+        # TODO: Make this thread safe
         self._mqtt.username_pw_set(_util.json_minimal(username))
 
-        response_code = self._mqtt.connect(HOST, 443, keepalive=10)
-        # TODO: Handle response code
-
-    def listen(self, on_message):
-        def real_on_message(client, userdata, message):
-            on_message(message.topic, message.payload)
-
-        self._mqtt.on_message = real_on_message
-
+    def listen(self):
         self._mqtt.loop_forever()  # TODO: retry_first_connection=True?
 
     def disconnect(self):
         self._mqtt.disconnect()
 
-    def set_foreground(self, state):
-        payload = _util.json_minimal({"foreground": state})
+    def set_foreground(self, value):
+        payload = _util.json_minimal({"foreground": value})
         info = self._mqtt.publish("/foreground_state", payload=payload, qos=1)
+        self._foreground = value
         # TODO: We can't wait for this, since the loop is running with .loop_forever()
         # info.wait_for_publish()
+
+    # def set_client_settings(self, available_when_in_foreground: bool):
+    #     data = {"make_user_available_when_in_foreground": available_when_in_foreground}
+    #     payload = _util.json_minimal(data)
+    #     info = self._mqtt.publish("/set_client_settings", payload=payload, qos=1)
+    #
+    # def send_additional_contacts(self, additional_contacts):
+    #     payload = _util.json_minimal({"additional_contacts": additional_contacts})
+    #     info = self._mqtt.publish("/send_additional_contacts", payload=payload, qos=1)

--- a/fbchat/_user.py
+++ b/fbchat/_user.py
@@ -192,17 +192,6 @@ class ActiveStatus(object):
     in_game = attr.ib(None)
 
     @classmethod
-    def _from_chatproxy_presence(cls, id_, data):
-        return cls(
-            active=data["p"] in [2, 3] if "p" in data else None,
-            last_active=data.get("lat"),
-            in_game=int(id_) in data.get("gamers", {}),
-        )
-
-    @classmethod
-    def _from_buddylist_overlay(cls, data, in_game=None):
-        return cls(
-            active=data["a"] in [2, 3] if "a" in data else None,
-            last_active=data.get("la"),
-            in_game=None,
-        )
+    def _from_orca_presence(cls, data):
+        # TODO: Handle `c` and `vc` keys (Probably some binary data)
+        return cls(active=data["p"] in [2, 3], last_active=data.get("l"), in_game=None)

--- a/fbchat/_util.py
+++ b/fbchat/_util.py
@@ -57,12 +57,24 @@ def now():
     return int(time() * 1000)
 
 
+def json_minimal(data):
+    """Get JSON data in minimal form."""
+    return json.dumps(data, separators=(",", ":"))
+
+
 def strip_json_cruft(text):
     """Removes `for(;;);` (and other cruft) that preceeds JSON responses."""
     try:
         return text[text.index("{") :]
     except ValueError:
         raise FBchatException("No JSON object found: {!r}".format(text))
+
+
+def get_cookie_header(session, host):
+    """Extract a cookie header from a requests session."""
+    return requests.cookies.get_cookie_header(
+        session.cookies, requests.Request("GET", host),
+    )
 
 
 def get_decoded_r(r):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ requires = [
     "attrs>=18.2",
     "requests~=2.19",
     "beautifulsoup4~=4.0",
+    "paho-mqtt~=1.5",
 ]
 description-file = "README.rst"
 classifiers = [


### PR DESCRIPTION
Uses the `paho.mqtt.python` library to add support for MQTT over WebSockets. @tulir's fork `fbchat-asyncio` has been very helpful in implementing this!

_This is fully backwards compatible!_

Fixes #490, fixes #483, fixes #460 and fixes #430.

After this is done, and has been released for a while (so it'll have some time to be tested in real world scenarios), I'll make an equivalent PR to `master`.