### PR TITLE
Rename uid

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -53,7 +53,7 @@ This is required for many of ``fbchat``'s functions, since Facebook differentiat
 Searching for group chats and finding their ID can be done via. `Client.search_for_groups`,
 and searching for users is possible via. `Client.search_for_users`. See :ref:`intro_fetching`
 
-You can get your own user ID by using `Client.uid`
+You can get your own user ID by using `Session.user_id`
 
 Getting the ID of a group chat is fairly trivial otherwise, since you only need to navigate to `<https://www.facebook.com/messages/>`_,
 click on the group you want to find the ID of, and then read the id from the address bar.
@@ -106,7 +106,7 @@ like adding users to and removing users from a group chat, logically only works 
 The simplest way of using ``fbchat`` is to send a message.
 The following snippet will, as you've probably already figured out, send the message ``test message`` to your account::
 
-    message_id = client.send(Message(text='test message'), thread_id=client.uid, thread_type=ThreadType.USER)
+    message_id = client.send(Message(text='test message'), thread_id=session.user_id, thread_type=ThreadType.USER)
 
 You can see a full example showing all the possible thread interactions with ``fbchat`` by going to :ref:`examples`
 
@@ -123,7 +123,7 @@ The following snippet will search for users by their name, take the first (and m
 
     users = client.search_for_users('<name of user>')
     user = users[0]
-    print("User's ID: {}".format(user.uid))
+    print("User's ID: {}".format(user.id))
     print("User's name: {}".format(user.name))
     print("User's profile picture URL: {}".format(user.photo))
     print("User's main URL: {}".format(user.url))

--- a/examples/echobot.py
+++ b/examples/echobot.py
@@ -9,7 +9,7 @@ class EchoBot(fbchat.Client):
         print("{} from {} in {}".format(message_object, thread_id, thread_type.name))
 
         # If you're not the author, echo
-        if author_id != session.user_id:
+        if author_id != self.session.user_id:
             self.send(message_object, thread_id=thread_id, thread_type=thread_type)
 
 

--- a/examples/echobot.py
+++ b/examples/echobot.py
@@ -3,13 +3,13 @@ import fbchat
 # Subclass fbchat.Client and override required methods
 class EchoBot(fbchat.Client):
     def on_message(self, author_id, message_object, thread_id, thread_type, **kwargs):
-        self.mark_as_delivered(thread_id, message_object.uid)
+        self.mark_as_delivered(thread_id, message_object.id)
         self.mark_as_read(thread_id)
 
         print("{} from {} in {}".format(message_object, thread_id, thread_type.name))
 
         # If you're not the author, echo
-        if author_id != self.uid:
+        if author_id != session.user_id:
             self.send(message_object, thread_id=thread_id, thread_type=thread_type)
 
 

--- a/examples/fetch.py
+++ b/examples/fetch.py
@@ -8,7 +8,7 @@ client = fbchat.Client(session)
 # Fetches a list of all users you're currently chatting with, as `User` objects
 users = client.fetch_all_users()
 
-print("users' IDs: {}".format([user.uid for user in users]))
+print("users' IDs: {}".format([user.id for user in users]))
 print("users' names: {}".format([user.name for user in users]))
 
 
@@ -25,7 +25,7 @@ print("users' names: {}".format([users[k].name for k in users]))
 # and then we just take the first one, aka. the most likely one:
 user = client.search_for_users("<name of user>")[0]
 
-print("user ID: {}".format(user.uid))
+print("user ID: {}".format(user.id))
 print("user's name: {}".format(user.name))
 print("user's photo: {}".format(user.photo))
 print("Is user client's friend: {}".format(user.is_friend))

--- a/examples/keepbot.py
+++ b/examples/keepbot.py
@@ -31,7 +31,7 @@ class KeepBot(fbchat.Client):
             self.change_thread_emoji(old_emoji, thread_id=thread_id)
 
     def on_people_added(self, added_ids, author_id, thread_id, **kwargs):
-        if old_thread_id == thread_id and author_id != self.uid:
+        if old_thread_id == thread_id and author_id != session.user_id:
             print("{} got added. They will be removed".format(added_ids))
             for added_id in added_ids:
                 self.remove_user_from_group(added_id, thread_id=thread_id)
@@ -40,8 +40,8 @@ class KeepBot(fbchat.Client):
         # No point in trying to add ourself
         if (
             old_thread_id == thread_id
-            and removed_id != self.uid
-            and author_id != self.uid
+            and removed_id != session.user_id
+            and author_id != session.user_id
         ):
             print("{} got removed. They will be re-added".format(removed_id))
             self.add_users_to_group(removed_id, thread_id=thread_id)

--- a/examples/keepbot.py
+++ b/examples/keepbot.py
@@ -31,7 +31,7 @@ class KeepBot(fbchat.Client):
             self.change_thread_emoji(old_emoji, thread_id=thread_id)
 
     def on_people_added(self, added_ids, author_id, thread_id, **kwargs):
-        if old_thread_id == thread_id and author_id != session.user_id:
+        if old_thread_id == thread_id and author_id != self.session.user_id:
             print("{} got added. They will be removed".format(added_ids))
             for added_id in added_ids:
                 self.remove_user_from_group(added_id, thread_id=thread_id)
@@ -40,8 +40,8 @@ class KeepBot(fbchat.Client):
         # No point in trying to add ourself
         if (
             old_thread_id == thread_id
-            and removed_id != session.user_id
-            and author_id != session.user_id
+            and removed_id != self.session.user_id
+            and author_id != self.session.user_id
         ):
             print("{} got removed. They will be re-added".format(removed_id))
             self.add_users_to_group(removed_id, thread_id=thread_id)

--- a/fbchat/_attachment.py
+++ b/fbchat/_attachment.py
@@ -8,7 +8,7 @@ class Attachment:
     """Represents a Facebook attachment."""
 
     #: The attachment ID
-    uid = attr.ib(None)
+    id = attr.ib(None)
 
 
 @attrs_default
@@ -56,7 +56,7 @@ class ShareAttachment(Attachment):
 
         url = data.get("url")
         return cls(
-            uid=data.get("deduplication_key"),
+            id=data.get("deduplication_key"),
             author=data["target"]["actors"][0]["id"]
             if data["target"].get("actors")
             else None,

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -44,15 +44,10 @@ class Client:
     """
 
     def __init__(self, session):
-        """Initialize and log in the client.
+        """Initialize the client model.
 
         Args:
-            email: Facebook ``email``, ``id`` or ``phone number``
-            password: Facebook account password
-            session_cookies (dict): Cookies from a previous session (Will default to login if these are invalid)
-
-        Raises:
-            FBchatException: On failed login
+            session: The session to use when making requests.
         """
         self._sticky, self._pool = (None, None)
         self._seq = "0"
@@ -60,6 +55,11 @@ class Client:
         self._mark_alive = True
         self._buddylist = dict()
         self._session = session
+
+    @property
+    def session(self):
+        """The session that's used when making requests."""
+        return self._session
 
     """
     INTERNAL REQUEST METHODS

--- a/fbchat/_client.py
+++ b/fbchat/_client.py
@@ -43,14 +43,6 @@ class Client:
     useful while listening).
     """
 
-    @property
-    def uid(self):
-        """The ID of the client.
-
-        Can be used as ``thread_id``. See :ref:`intro_threads` for more info.
-        """
-        return self._uid
-
     def __init__(self, session):
         """Initialize and log in the client.
 
@@ -68,7 +60,6 @@ class Client:
         self._mark_alive = True
         self._buddylist = dict()
         self._session = session
-        self._uid = session.user_id
 
     """
     INTERNAL REQUEST METHODS
@@ -192,12 +183,12 @@ class Client:
         users_to_fetch = []  # It's more efficient to fetch all users in one request
         for thread in threads:
             if thread.type == ThreadType.USER:
-                if thread.uid not in [user.uid for user in users]:
+                if thread.id not in [user.id for user in users]:
                     users.append(thread)
             elif thread.type == ThreadType.GROUP:
                 for user_id in thread.participants:
                     if (
-                        user_id not in [user.uid for user in users]
+                        user_id not in [user.id for user in users]
                         and user_id not in users_to_fetch
                     ):
                         users_to_fetch.append(user_id)
@@ -214,7 +205,7 @@ class Client:
         Raises:
             FBchatException: If request failed
         """
-        data = {"viewer": self._uid}
+        data = {"viewer": self._session.user_id}
         j = self._payload_post("/chat/user_info_all", data)
 
         users = []
@@ -837,7 +828,7 @@ class Client:
             elif i["node"].get("__typename") == "MessageVideo":
                 yield VideoAttachment._from_list(i)
             else:
-                yield Attachment(uid=i["node"].get("legacy_attachment_id"))
+                yield Attachment(id=i["node"].get("legacy_attachment_id"))
             del j[thread_id]["message_shared_media"]["edges"][0]
 
     """
@@ -873,7 +864,7 @@ class Client:
         Raises:
             FBchatException: If request failed
         """
-        thread = thread_type._to_class()(uid=thread_id)
+        thread = thread_type._to_class()(id=thread_id)
         data = thread._to_send_data()
         data.update(message._to_send_data())
         return self._do_send_request(data)
@@ -892,7 +883,7 @@ class Client:
         Raises:
             FBchatException: If request failed
         """
-        thread = thread_type._to_class()(uid=thread_id)
+        thread = thread_type._to_class()(id=thread_id)
         data = thread._to_send_data()
         data["action_type"] = "ma-type:user-generated-message"
         data["lightweight_action_attachment[lwa_state]"] = (
@@ -965,7 +956,7 @@ class Client:
     def _send_location(
         self, location, current=True, message=None, thread_id=None, thread_type=None
     ):
-        thread = thread_type._to_class()(uid=thread_id)
+        thread = thread_type._to_class()(id=thread_id)
         data = thread._to_send_data()
         if message is not None:
             data.update(message._to_send_data())
@@ -1033,7 +1024,7 @@ class Client:
 
         `files` should be a list of tuples, with a file's ID and mimetype.
         """
-        thread = thread_type._to_class()(uid=thread_id)
+        thread = thread_type._to_class()(id=thread_id)
         data = thread._to_send_data()
         data.update(self._old_message(message)._to_send_data())
         data["action_type"] = "ma-type:user-generated-message"
@@ -1179,7 +1170,7 @@ class Client:
         if len(user_ids) < 2:
             raise ValueError("Error when creating group: Not enough participants")
 
-        for i, user_id in enumerate(user_ids + [self._uid]):
+        for i, user_id in enumerate(user_ids + [self._session.user_id]):
             data["specific_to_list[{}]".format(i)] = "fbid:{}".format(user_id)
 
         message_id, thread_id = self._do_send_request(data, get_thread_id=True)
@@ -1199,7 +1190,7 @@ class Client:
         Raises:
             FBchatException: If request failed
         """
-        data = Group(uid=thread_id)._to_send_data()
+        data = Group(id=thread_id)._to_send_data()
 
         data["action_type"] = "ma-type:log-message"
         data["log_message_type"] = "log:subscribe"
@@ -1207,7 +1198,7 @@ class Client:
         user_ids = _util.require_list(user_ids)
 
         for i, user_id in enumerate(user_ids):
-            if user_id == self._uid:
+            if user_id == self._session.user_id:
                 raise ValueError(
                     "Error when adding users: Cannot add self to group thread"
                 )
@@ -1283,7 +1274,7 @@ class Client:
 
         data = {
             "client_mutation_id": "0",
-            "actor_id": self._uid,
+            "actor_id": self._session.user_id,
             "thread_fbid": thread_id,
             "user_ids": user_ids,
             "response": "ACCEPT" if approve else "DENY",
@@ -1456,7 +1447,7 @@ class Client:
         data = {
             "action": "ADD_REACTION" if reaction else "REMOVE_REACTION",
             "client_mutation_id": "1",
-            "actor_id": self._uid,
+            "actor_id": self._session.user_id,
             "message_id": str(message_id),
             "reaction": reaction.value if reaction else None,
         }
@@ -1501,7 +1492,7 @@ class Client:
             FBchatException: If request failed
         """
         data = {
-            "event_reminder_id": plan.uid,
+            "event_reminder_id": plan.id,
             "delete": "false",
             "date": _util.datetime_to_seconds(new_plan.time),
             "location_name": new_plan.location or "",
@@ -1520,7 +1511,7 @@ class Client:
         Raises:
             FBchatException: If request failed
         """
-        data = {"event_reminder_id": plan.uid, "delete": "true", "acontext": ACONTEXT}
+        data = {"event_reminder_id": plan.id, "delete": "true", "acontext": ACONTEXT}
         j = self._payload_post("/ajax/eventreminder/submit", data)
 
     def change_plan_participation(self, plan, take_part=True):
@@ -1534,7 +1525,7 @@ class Client:
             FBchatException: If request failed
         """
         data = {
-            "event_reminder_id": plan.uid,
+            "event_reminder_id": plan.id,
             "guest_state": "GOING" if take_part else "DECLINED",
             "acontext": ACONTEXT,
         }
@@ -1913,14 +1904,14 @@ class Client:
     def _ping(self):
         data = {
             "seq": self._seq,
-            "channel": "p_" + self._uid,
+            "channel": "p_" + self._session.user_id,
             "clientid": self._session._client_id,
             "partition": -2,
             "cap": 0,
-            "uid": self._uid,
+            "uid": self._session.user_id,
             "sticky_token": self._sticky,
             "sticky_pool": self._pool,
-            "viewer_uid": self._uid,
+            "viewer_uid": self._session.user_id,
             "state": "active",
         }
         j = self._get(
@@ -2461,7 +2452,7 @@ class Client:
                     replied_to = Message._from_reply(i["repliedToMessage"])
                     message = Message._from_reply(i["message"], replied_to)
                     self.on_message(
-                        mid=message.uid,
+                        mid=message.id,
                         author_id=message.author,
                         message_object=message,
                         thread_id=thread_id,
@@ -2537,7 +2528,7 @@ class Client:
                         thread_id = str(thread_id)
                     else:
                         thread_type = ThreadType.USER
-                        if author_id == self._uid:
+                        if author_id == self._session.user_id:
                             thread_id = m.get("to")
                         else:
                             thread_id = author_id

--- a/fbchat/_file.py
+++ b/fbchat/_file.py
@@ -24,7 +24,7 @@ class FileAttachment(Attachment):
             size=size,
             name=data.get("filename"),
             is_malicious=data.get("is_malicious"),
-            uid=data.get("message_file_fbid"),
+            id=data.get("message_file_fbid"),
         )
 
 
@@ -86,7 +86,7 @@ class ImageAttachment(Attachment):
             height=data.get("original_dimensions", {}).get("height"),
             is_animated=data["__typename"] == "MessageAnimatedImage",
             previews={p for p in previews if p},
-            uid=data.get("legacy_attachment_id"),
+            id=data.get("legacy_attachment_id"),
         )
 
     @classmethod
@@ -103,7 +103,7 @@ class ImageAttachment(Attachment):
             width=data["original_dimensions"].get("x"),
             height=data["original_dimensions"].get("y"),
             previews={p for p in previews if p},
-            uid=data["legacy_attachment_id"],
+            id=data["legacy_attachment_id"],
         )
 
 
@@ -139,7 +139,7 @@ class VideoAttachment(Attachment):
             duration=_util.millis_to_timedelta(data.get("playable_duration_in_ms")),
             preview_url=data.get("playable_url"),
             previews={p for p in previews if p},
-            uid=data.get("legacy_attachment_id"),
+            id=data.get("legacy_attachment_id"),
         )
 
     @classmethod
@@ -151,7 +151,7 @@ class VideoAttachment(Attachment):
             duration=_util.millis_to_timedelta(media.get("playable_duration_in_ms")),
             preview_url=media.get("playable_url"),
             previews={image} if image else {},
-            uid=data["target"].get("video_id"),
+            id=data["target"].get("video_id"),
         )
 
     @classmethod
@@ -167,7 +167,7 @@ class VideoAttachment(Attachment):
             width=data["original_dimensions"].get("x"),
             height=data["original_dimensions"].get("y"),
             previews=previews,
-            uid=data["legacy_attachment_id"],
+            id=data["legacy_attachment_id"],
         )
 
 
@@ -182,7 +182,7 @@ def graphql_to_attachment(data, size=None):
     elif _type == "MessageFile":
         return FileAttachment._from_graphql(data, size=size)
 
-    return Attachment(uid=data.get("legacy_attachment_id"))
+    return Attachment(id=data.get("legacy_attachment_id"))
 
 
 def graphql_to_subattachment(data):

--- a/fbchat/_group.py
+++ b/fbchat/_group.py
@@ -10,6 +10,16 @@ class Group(Thread):
 
     type = ThreadType.GROUP
 
+    #: The group's picture
+    photo = attr.ib(None)
+    #: The name of the group
+    name = attr.ib(None)
+    #: Datetime when the group was last active / when the last message was sent
+    last_active = attr.ib(None)
+    #: Number of messages in the group
+    message_count = attr.ib(None)
+    #: Set `Plan`
+    plan = attr.ib(None)
     #: Unique list (set) of the group thread's participant user IDs
     participants = attr.ib(factory=set)
     #: A dictionary, containing user nicknames mapped to their IDs

--- a/fbchat/_group.py
+++ b/fbchat/_group.py
@@ -52,7 +52,7 @@ class Group(Thread):
             plan = _plan.Plan._from_graphql(data["event_reminders"]["nodes"][0])
 
         return cls(
-            uid=data["thread_key"]["thread_fbid"],
+            id=data["thread_key"]["thread_fbid"],
             participants=set(
                 [
                     node["messaging_actor"]["id"]
@@ -81,4 +81,4 @@ class Group(Thread):
         )
 
     def _to_send_data(self):
-        return {"thread_fbid": self.uid}
+        return {"thread_fbid": self.id}

--- a/fbchat/_location.py
+++ b/fbchat/_location.py
@@ -33,7 +33,7 @@ class LocationAttachment(Attachment):
             latitude, longitude = None, None
 
         return cls(
-            uid=int(data["deduplication_key"]),
+            id=int(data["deduplication_key"]),
             latitude=latitude,
             longitude=longitude,
             image=Image._from_uri_or_none(data["media"].get("image"))
@@ -58,7 +58,7 @@ class LiveLocationAttachment(LocationAttachment):
     @classmethod
     def _from_pull(cls, data):
         return cls(
-            uid=data["id"],
+            id=data["id"],
             latitude=data["coordinate"]["latitude"] / (10 ** 8)
             if not data.get("stopReason")
             else None,
@@ -80,7 +80,7 @@ class LiveLocationAttachment(LocationAttachment):
             image = Image._from_uri(media["image"])
 
         return cls(
-            uid=int(target["live_location_id"]),
+            id=int(target["live_location_id"]),
             latitude=target["coordinate"]["latitude"]
             if target.get("coordinate")
             else None,

--- a/fbchat/_message.py
+++ b/fbchat/_message.py
@@ -85,7 +85,7 @@ class Message:
     #: A `EmojiSize`. Size of a sent emoji
     emoji_size = attr.ib(None)
     #: The message ID
-    uid = attr.ib(None)
+    id = attr.ib(None)
     #: ID of the sender
     author = attr.ib(None)
     #: Datetime of when the message was sent
@@ -186,7 +186,7 @@ class Message:
                 data["sticker_id"] = self.emoji_size.value
 
         if self.sticker:
-            data["sticker_id"] = self.sticker.uid
+            data["sticker_id"] = self.sticker.id
 
         if self.quick_replies:
             xmd = {"quick_replies": []}
@@ -255,7 +255,7 @@ class Message:
                 Mention._from_range(m) for m in data["message"].get("ranges") or ()
             ],
             emoji_size=EmojiSize._from_tags(tags),
-            uid=str(data["message_id"]),
+            id=str(data["message_id"]),
             author=str(data["message_sender"]["id"]),
             created_at=created_at,
             is_read=not data["unread"] if data.get("unread") is not None else None,
@@ -272,7 +272,7 @@ class Message:
             attachments=attachments,
             quick_replies=cls._parse_quick_replies(data.get("platform_xmd_encoded")),
             unsent=unsent,
-            reply_to_id=replied_to.uid if replied_to else None,
+            reply_to_id=replied_to.id if replied_to else None,
             replied_to=replied_to,
             forwarded=cls._get_forwarded_from_tags(tags),
         )
@@ -311,14 +311,14 @@ class Message:
                 for m in _util.parse_json(data.get("data", {}).get("prng", "[]"))
             ],
             emoji_size=EmojiSize._from_tags(tags),
-            uid=metadata.get("messageId"),
+            id=metadata.get("messageId"),
             author=str(metadata.get("actorFbId")),
             created_at=_util.millis_to_datetime(metadata.get("timestamp")),
             sticker=sticker,
             attachments=attachments,
             quick_replies=cls._parse_quick_replies(data.get("platform_xmd_encoded")),
             unsent=unsent,
-            reply_to_id=replied_to.uid if replied_to else None,
+            reply_to_id=replied_to.id if replied_to else None,
             replied_to=replied_to,
             forwarded=cls._get_forwarded_from_tags(tags),
         )
@@ -374,7 +374,7 @@ class Message:
             text=data.get("body"),
             mentions=mentions,
             emoji_size=EmojiSize._from_tags(tags),
-            uid=mid,
+            id=mid,
             author=author,
             created_at=created_at,
             sticker=sticker,
@@ -391,7 +391,7 @@ def graphql_to_extensible_attachment(data):
 
     target = story.get("target")
     if not target:
-        return _attachment.UnsentMessage(uid=data.get("legacy_attachment_id"))
+        return _attachment.UnsentMessage(id=data.get("legacy_attachment_id"))
 
     _type = target["__typename"]
     if _type == "MessageLocation":

--- a/fbchat/_page.py
+++ b/fbchat/_page.py
@@ -42,7 +42,7 @@ class Page(Thread):
             plan = _plan.Plan._from_graphql(data["event_reminders"]["nodes"][0])
 
         return cls(
-            uid=data["id"],
+            id=data["id"],
             url=data.get("url"),
             city=data.get("city").get("name"),
             category=data.get("category_type"),

--- a/fbchat/_page.py
+++ b/fbchat/_page.py
@@ -10,6 +10,16 @@ class Page(Thread):
 
     type = ThreadType.PAGE
 
+    #: The page's picture
+    photo = attr.ib(None)
+    #: The name of the page
+    name = attr.ib(None)
+    #: Datetime when the thread was last active / when the last message was sent
+    last_active = attr.ib(None)
+    #: Number of messages in the thread
+    message_count = attr.ib(None)
+    #: Set `Plan`
+    plan = attr.ib(None)
     #: The page's custom URL
     url = attr.ib(None)
     #: The name of the page's location city

--- a/fbchat/_plan.py
+++ b/fbchat/_plan.py
@@ -19,7 +19,7 @@ class Plan:
     #: Plan title
     title = attr.ib()
     #: ID of the plan
-    uid = attr.ib(None)
+    id = attr.ib(None)
     #: Plan location name
     location = attr.ib(None, converter=lambda x: x or "")
     #: Plan location ID
@@ -59,7 +59,7 @@ class Plan:
     @classmethod
     def _from_pull(cls, data):
         return cls(
-            uid=data.get("event_id"),
+            id=data.get("event_id"),
             time=_util.seconds_to_datetime(int(data.get("event_time"))),
             title=data.get("event_title"),
             location=data.get("event_location_name"),
@@ -74,7 +74,7 @@ class Plan:
     @classmethod
     def _from_fetch(cls, data):
         return cls(
-            uid=data.get("oid"),
+            id=data.get("oid"),
             time=_util.seconds_to_datetime(data.get("event_time")),
             title=data.get("title"),
             location=data.get("location_name"),
@@ -86,7 +86,7 @@ class Plan:
     @classmethod
     def _from_graphql(cls, data):
         return cls(
-            uid=data.get("id"),
+            id=data.get("id"),
             time=_util.seconds_to_datetime(data.get("time")),
             title=data.get("event_title"),
             location=data.get("location_name"),

--- a/fbchat/_poll.py
+++ b/fbchat/_poll.py
@@ -13,12 +13,12 @@ class Poll:
     #: Options count
     options_count = attr.ib(None)
     #: ID of the poll
-    uid = attr.ib(None)
+    id = attr.ib(None)
 
     @classmethod
     def _from_graphql(cls, data):
         return cls(
-            uid=int(data["id"]),
+            id=int(data["id"]),
             title=data.get("title") if data.get("title") else data.get("text"),
             options=[PollOption._from_graphql(m) for m in data.get("options")],
             options_count=data.get("total_count"),
@@ -38,7 +38,7 @@ class PollOption:
     #: Votes count
     votes_count = attr.ib(None)
     #: ID of the poll option
-    uid = attr.ib(None)
+    id = attr.ib(None)
 
     @classmethod
     def _from_graphql(cls, data):
@@ -49,7 +49,7 @@ class PollOption:
         else:
             vote = data["viewer_has_voted"] == "true"
         return cls(
-            uid=int(data["id"]),
+            id=int(data["id"]),
             text=data.get("text"),
             vote=vote,
             voters=(

--- a/fbchat/_sticker.py
+++ b/fbchat/_sticker.py
@@ -35,7 +35,7 @@ class Sticker(Attachment):
             return None
 
         return cls(
-            uid=data["id"],
+            id=data["id"],
             pack=data["pack"].get("id") if data.get("pack") else None,
             is_animated=bool(data.get("sprite_image")),
             medium_sprite_image=data["sprite_image"].get("uri")

--- a/fbchat/_thread.py
+++ b/fbchat/_thread.py
@@ -75,16 +75,6 @@ class Thread:
     uid = attr.ib(converter=str)
     #: Specifies the type of thread. Can be used a ``thread_type``. See :ref:`intro_threads` for more info
     type = None
-    #: The thread's picture
-    photo = attr.ib(None)
-    #: The name of the thread
-    name = attr.ib(None)
-    #: Datetime when the thread was last active / when the last message was sent
-    last_active = attr.ib(None)
-    #: Number of messages in the thread
-    message_count = attr.ib(None)
-    #: Set `Plan`
-    plan = attr.ib(None)
 
     @staticmethod
     def _parse_customization_info(data):

--- a/fbchat/_thread.py
+++ b/fbchat/_thread.py
@@ -71,8 +71,8 @@ class ThreadColor(Enum):
 class Thread:
     """Represents a Facebook thread."""
 
-    #: The unique identifier of the thread. Can be used a ``thread_id``. See :ref:`intro_threads` for more info
-    uid = attr.ib(converter=str)
+    #: The unique identifier of the thread.
+    id = attr.ib(converter=str)
     #: Specifies the type of thread. Can be used a ``thread_type``. See :ref:`intro_threads` for more info
     type = None
 
@@ -95,15 +95,15 @@ class Thread:
             for k in info.get("participant_customizations", []):
                 rtn["nicknames"][k["participant_id"]] = k.get("nickname")
         elif info.get("participant_customizations"):
-            uid = data.get("thread_key", {}).get("other_user_id") or data.get("id")
+            user_id = data.get("thread_key", {}).get("other_user_id") or data.get("id")
             pc = info["participant_customizations"]
             if len(pc) > 0:
-                if pc[0].get("participant_id") == uid:
+                if pc[0].get("participant_id") == user_id:
                     rtn["nickname"] = pc[0].get("nickname")
                 else:
                     rtn["own_nickname"] = pc[0].get("nickname")
             if len(pc) > 1:
-                if pc[1].get("participant_id") == uid:
+                if pc[1].get("participant_id") == user_id:
                     rtn["nickname"] = pc[1].get("nickname")
                 else:
                     rtn["own_nickname"] = pc[1].get("nickname")
@@ -111,4 +111,4 @@ class Thread:
 
     def _to_send_data(self):
         # TODO: Only implement this in subclasses
-        return {"other_user_fbid": self.uid}
+        return {"other_user_fbid": self.id}

--- a/fbchat/_user.py
+++ b/fbchat/_user.py
@@ -47,6 +47,16 @@ class User(Thread):
 
     type = ThreadType.USER
 
+    #: The user's picture
+    photo = attr.ib(None)
+    #: The name of the user
+    name = attr.ib(None)
+    #: Datetime when the thread was last active / when the last message was sent
+    last_active = attr.ib(None)
+    #: Number of messages in the thread
+    message_count = attr.ib(None)
+    #: Set `Plan`
+    plan = attr.ib(None)
     #: The profile URL
     url = attr.ib(None)
     #: The users first name

--- a/fbchat/_user.py
+++ b/fbchat/_user.py
@@ -88,7 +88,7 @@ class User(Thread):
             plan = _plan.Plan._from_graphql(data["event_reminders"]["nodes"][0])
 
         return cls(
-            uid=data["id"],
+            id=data["id"],
             url=data.get("url"),
             first_name=data.get("first_name"),
             last_name=data.get("last_name"),
@@ -133,7 +133,7 @@ class User(Thread):
             plan = _plan.Plan._from_graphql(data["event_reminders"]["nodes"][0])
 
         return cls(
-            uid=user["id"],
+            id=user["id"],
             url=user.get("url"),
             name=user.get("name"),
             first_name=first_name,
@@ -154,7 +154,7 @@ class User(Thread):
     @classmethod
     def _from_all_fetch(cls, data):
         return cls(
-            uid=data["id"],
+            id=data["id"],
             first_name=data.get("firstName"),
             url=data.get("uri"),
             photo=Image(url=data.get("thumbSrc")),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from fbchat import ThreadType, Message, Mention
 
 @pytest.fixture(scope="session")
 def user(client2):
-    return {"id": client2.uid, "type": ThreadType.USER}
+    return {"id": client2.id, "type": ThreadType.USER}
 
 
 @pytest.fixture(scope="session")
@@ -88,7 +88,7 @@ def catch_event(client2):
     try:
         # Make the client send a messages to itself, so the blocking pull request will return
         # This is probably not safe, since the client is making two requests simultaneously
-        client2.send(Message(text=random_hex()), client2.uid)
+        client2.send(Message(text=random_hex()), client2.id)
     finally:
         t.join()
 
@@ -97,8 +97,8 @@ def catch_event(client2):
 def compare(client, thread):
     def inner(caught_event, **kwargs):
         d = {
-            "author_id": client.uid,
-            "thread_id": client.uid
+            "author_id": client.id,
+            "thread_id": client.id
             if thread["type"] == ThreadType.USER
             else thread["id"],
             "thread_type": thread["type"],
@@ -114,10 +114,10 @@ def message_with_mentions(request, client, client2, group):
     text = "Hi there ["
     mentions = []
     if "me" in request.param:
-        mentions.append(Mention(thread_id=client.uid, offset=len(text), length=2))
+        mentions.append(Mention(thread_id=client.id, offset=len(text), length=2))
         text += "me, "
     if "other" in request.param:
-        mentions.append(Mention(thread_id=client2.uid, offset=len(text), length=5))
+        mentions.append(Mention(thread_id=client2.id, offset=len(text), length=5))
         text += "other, "
     # Unused, because Facebook don't properly support sending mentions with groups as targets
     if "group" in request.param:

--- a/tests/test_attachment.py
+++ b/tests/test_attachment.py
@@ -26,7 +26,7 @@ def test_parse_unsent_message():
         "genie_attachment": {"genie_message": None},
     }
     assert UnsentMessage(
-        uid="ee.mid.$xyz"
+        id="ee.mid.$xyz"
     ) == fbchat._message.graphql_to_extensible_attachment(data)
 
 
@@ -75,7 +75,7 @@ def test_share_from_graphql_link():
         image=None,
         original_image_url=None,
         attachments=[],
-        uid="ee.mid.$xyz",
+        id="ee.mid.$xyz",
     ) == ShareAttachment._from_graphql(data)
 
 
@@ -128,7 +128,7 @@ def test_share_from_graphql_link_with_image():
         ),
         original_image_url="https://www.facebook.com/rsrc.php/v3/x.png",
         attachments=[],
-        uid="deadbeef123",
+        id="deadbeef123",
     ) == ShareAttachment._from_graphql(data)
 
 
@@ -194,7 +194,7 @@ def test_share_from_graphql_video():
         ),
         original_image_url="https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg",
         attachments=[],
-        uid="ee.mid.$gAAT4Sw1WSGhzQ9uRWVtEpZHZ8ZPV",
+        id="ee.mid.$gAAT4Sw1WSGhzQ9uRWVtEpZHZ8ZPV",
     ) == ShareAttachment._from_graphql(data)
 
 
@@ -315,7 +315,7 @@ def test_share_with_image_subattachment():
         ),
         original_image_url="https://scontent-arn2-1.xx.fbcdn.net/v/t1.0-9/1.jpg",
         attachments=[None],
-        uid="deadbeef123",
+        id="deadbeef123",
     ) == ShareAttachment._from_graphql(data)
 
 
@@ -444,7 +444,7 @@ def test_share_with_video_subattachment():
         original_image_url="https://scontent-arn2-1.xx.fbcdn.net/v/t15.5256-10/p180x540/1.jpg",
         attachments=[
             fbchat.VideoAttachment(
-                uid="2222",
+                id="2222",
                 duration=datetime.timedelta(seconds=24, microseconds=469000),
                 preview_url="https://video-arn2-1.xx.fbcdn.net/v/t42.9040-2/vid.mp4",
                 previews={
@@ -456,5 +456,5 @@ def test_share_with_video_subattachment():
                 },
             )
         ],
-        uid="deadbeef123",
+        id="deadbeef123",
     ) == ShareAttachment._from_graphql(data)

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -28,7 +28,7 @@ def test_fetch_message_emoji(client, emoji, emoji_size):
     (message,) = client.fetch_thread_messages(limit=1)
 
     assert subset(
-        vars(message), uid=mid, author=client.uid, text=emoji, emoji_size=emoji_size
+        vars(message), id=mid, author=client.id, text=emoji, emoji_size=emoji_size
     )
 
 
@@ -38,7 +38,7 @@ def test_fetch_message_info_emoji(client, thread, emoji, emoji_size):
     message = client.fetch_message_info(mid, thread_id=thread["id"])
 
     assert subset(
-        vars(message), uid=mid, author=client.uid, text=emoji, emoji_size=emoji_size
+        vars(message), id=mid, author=client.id, text=emoji, emoji_size=emoji_size
     )
 
 
@@ -47,7 +47,7 @@ def test_fetch_message_mentions(client, thread, message_with_mentions):
     (message,) = client.fetch_thread_messages(limit=1)
 
     assert subset(
-        vars(message), uid=mid, author=client.uid, text=message_with_mentions.text
+        vars(message), id=mid, author=client.id, text=message_with_mentions.text
     )
     # The mentions are not ordered by offset
     for m in message.mentions:
@@ -59,7 +59,7 @@ def test_fetch_message_info_mentions(client, thread, message_with_mentions):
     message = client.fetch_message_info(mid, thread_id=thread["id"])
 
     assert subset(
-        vars(message), uid=mid, author=client.uid, text=message_with_mentions.text
+        vars(message), id=mid, author=client.id, text=message_with_mentions.text
     )
     # The mentions are not ordered by offset
     for m in message.mentions:
@@ -71,8 +71,8 @@ def test_fetch_message_sticker(client, sticker):
     mid = client.send(Message(sticker=sticker))
     (message,) = client.fetch_thread_messages(limit=1)
 
-    assert subset(vars(message), uid=mid, author=client.uid)
-    assert subset(vars(message.sticker), uid=sticker.uid)
+    assert subset(vars(message), id=mid, author=client.id)
+    assert subset(vars(message.sticker), id=sticker.id)
 
 
 @pytest.mark.parametrize("sticker", STICKER_LIST)
@@ -80,8 +80,8 @@ def test_fetch_message_info_sticker(client, thread, sticker):
     mid = client.send(Message(sticker=sticker))
     message = client.fetch_message_info(mid, thread_id=thread["id"])
 
-    assert subset(vars(message), uid=mid, author=client.uid)
-    assert subset(vars(message.sticker), uid=sticker.uid)
+    assert subset(vars(message), id=mid, author=client.id)
+    assert subset(vars(message.sticker), id=sticker.id)
 
 
 def test_fetch_info(client1, group):
@@ -98,4 +98,4 @@ def test_fetch_image_url(client):
     )
     (message,) = client.fetch_thread_messages(limit=1)
 
-    assert client.fetch_image_url(message.attachments[0].uid)
+    assert client.fetch_image_url(message.attachments[0].id)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -30,7 +30,7 @@ def test_imageattachment_from_list():
         "photo_encodings": [],
     }
     assert ImageAttachment(
-        uid="1234",
+        id="1234",
         width=2833,
         height=1367,
         previews={
@@ -70,7 +70,7 @@ def test_videoattachment_from_list():
         "original_dimensions": {"x": 640, "y": 368},
     }
     assert VideoAttachment(
-        uid="1234",
+        id="1234",
         width=640,
         height=368,
         previews={
@@ -97,7 +97,7 @@ def test_graphql_to_attachment_empty():
 
 def test_graphql_to_attachment_simple():
     data = {"__typename": "Unknown", "legacy_attachment_id": "1234"}
-    assert fbchat.Attachment(uid="1234") == graphql_to_attachment(data)
+    assert fbchat.Attachment(id="1234") == graphql_to_attachment(data)
 
 
 def test_graphql_to_attachment_file():
@@ -114,7 +114,7 @@ def test_graphql_to_attachment_file():
         "url_skipshim": True,
     }
     assert FileAttachment(
-        uid="1234",
+        id="1234",
         url="https://l.facebook.com/l.php?u=https%3A%2F%2Fcdn.fbsbx.com%2Fv%2Ffile.txt&h=AT1...&s=1",
         size=None,
         name="file.txt",
@@ -136,7 +136,7 @@ def test_graphql_to_attachment_audio():
         "url_skipshim": True,
     }
     assert AudioAttachment(
-        uid=None,
+        id=None,
         filename="audio.mp3",
         url="https://cdn.fbsbx.com/v/audio.mp3?dl=1",
         duration=datetime.timedelta(seconds=27, microseconds=745000),
@@ -169,7 +169,7 @@ def test_graphql_to_attachment_image1():
         "blurred_image_uri": None,
     }
     assert ImageAttachment(
-        uid="1234",
+        id="1234",
         original_extension="png",
         width=None,
         height=None,
@@ -205,7 +205,7 @@ def test_graphql_to_attachment_image2():
         "original_dimensions": {"x": 128, "y": 128},
     }
     assert ImageAttachment(
-        uid="1234",
+        id="1234",
         original_extension="gif",
         width=None,
         height=None,
@@ -244,7 +244,7 @@ def test_graphql_to_attachment_video():
         },
     }
     assert VideoAttachment(
-        uid="1234",
+        id="1234",
         width=None,
         height=None,
         duration=datetime.timedelta(seconds=6),
@@ -347,7 +347,7 @@ def test_graphql_to_subattachment_video():
         },
     }
     assert VideoAttachment(
-        uid="1234",
+        id="1234",
         duration=datetime.timedelta(seconds=24, microseconds=469000),
         preview_url="https://video-arn2-1.xx.fbcdn.net/v/t42.9040-2/vid.mp4",
         previews={

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -26,7 +26,7 @@ def test_group_from_graphql():
         "event_reminders": {"nodes": []},
     }
     assert Group(
-        uid="11223344",
+        id="11223344",
         photo=None,
         name="Group ABC",
         last_active=None,

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -35,7 +35,7 @@ def test_location_attachment_from_graphql():
         "subattachments": [],
     }
     assert LocationAttachment(
-        uid=400828513928715,
+        id=400828513928715,
         latitude=55.4,
         longitude=12.4322,
         image=fbchat.Image(
@@ -80,7 +80,7 @@ def test_live_location_from_graphql_expired():
         "subattachments": [],
     }
     assert LiveLocationAttachment(
-        uid=2254535444791641,
+        id=2254535444791641,
         name="Location-sharing ended",
         expires_at=datetime.datetime(
             2019, 1, 4, 18, 25, 45, tzinfo=datetime.timezone.utc

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -99,7 +99,7 @@ def test_message_to_send_data_mentions():
 
 
 def test_message_to_send_data_sticker():
-    msg = Message(sticker=fbchat.Sticker(uid="123"))
+    msg = Message(sticker=fbchat.Sticker(id="123"))
     assert {
         "action_type": "ma-type:user-generated-message",
         "sticker_id": "123",

--- a/tests/test_message_management.py
+++ b/tests/test_message_management.py
@@ -18,4 +18,4 @@ def test_delete_messages(client):
     mid2 = client.send(Message(text=text2))
     client.delete_messages(mid2)
     (message,) = client.fetch_thread_messages(limit=1)
-    assert subset(vars(message), uid=mid1, author=client.uid, text=text1)
+    assert subset(vars(message), id=mid1, author=client.id, text=text1)

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -12,7 +12,7 @@ def test_page_from_graphql():
         "city": None,
     }
     assert Page(
-        uid="123456",
+        id="123456",
         photo=fbchat.Image(url="https://scontent-arn2-1.xx.fbcdn.net/v/..."),
         name="Some school",
         url="https://www.facebook.com/some-school/",

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -36,7 +36,7 @@ def test_plan_from_pull():
         ),
     }
     assert Plan(
-        uid="1111",
+        id="1111",
         time=datetime.datetime(2017, 7, 14, 2, 40, tzinfo=datetime.timezone.utc),
         title="abc",
         author_id="1234",
@@ -93,7 +93,7 @@ def test_plan_from_fetch():
         },
     }
     assert Plan(
-        uid=1111,
+        id=1111,
         time=datetime.datetime(2017, 7, 14, 2, 40, tzinfo=datetime.timezone.utc),
         title="abc",
         location="",
@@ -139,7 +139,7 @@ def test_plan_from_graphql():
         title="abc",
         location="",
         location_id="",
-        uid="1111",
+        id="1111",
         author_id="1234",
         guests={
             "1234": GuestStatus.INVITED,

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -26,13 +26,13 @@ def plan_data(request, client, user, thread, catch_event, compare):
         vars(x.res["plan"]),
         time=request.param.time,
         title=request.param.title,
-        author_id=client.uid,
-        going=[client.uid],
+        author_id=client.id,
+        going=[client.id],
         declined=[],
     )
     plan_id = x.res["plan"]
     assert user["id"] in x.res["plan"].invited
-    request.param.uid = x.res["plan"].uid
+    request.param.id = x.res["plan"].id
     yield x.res, request.param
     with catch_event("on_plan_deleted") as x:
         client.delete_plan(plan_id)
@@ -46,9 +46,9 @@ def test_create_delete_plan(plan_data):
 
 def test_fetch_plan_info(client, catch_event, plan_data):
     event, plan = plan_data
-    fetched_plan = client.fetch_plan_info(plan.uid)
+    fetched_plan = client.fetch_plan_info(plan.id)
     assert subset(
-        vars(fetched_plan), time=plan.time, title=plan.title, author_id=int(client.uid)
+        vars(fetched_plan), time=plan.time, title=plan.title, author_id=int(client.id)
     )
 
 
@@ -64,9 +64,9 @@ def test_change_plan_participation(
         vars(x.res["plan"]),
         time=plan.time,
         title=plan.title,
-        author_id=client.uid,
-        going=[client.uid] if take_part else [],
-        declined=[client.uid] if not take_part else [],
+        author_id=client.id,
+        going=[client.id] if take_part else [],
+        declined=[client.id] if not take_part else [],
     )
 
 
@@ -81,7 +81,7 @@ def test_edit_plan(client, thread, catch_event, compare, plan_data):
         vars(x.res["plan"]),
         time=new_plan.time,
         title=new_plan.title,
-        author_id=client.uid,
+        author_id=client.id,
     )
 
 
@@ -93,7 +93,7 @@ def test_on_plan_ended(client, thread, catch_event, compare):
         x.wait(180)
     assert subset(
         x.res,
-        thread_id=client.uid if thread["type"] == ThreadType.USER else thread["id"],
+        thread_id=client.id if thread["type"] == ThreadType.USER else thread["id"],
         thread_type=thread["type"],
     )
 

--- a/tests/test_poll.py
+++ b/tests/test_poll.py
@@ -10,7 +10,7 @@ def test_poll_option_from_graphql_unvoted():
         "voters": [],
     }
     assert PollOption(
-        text="abc", vote=False, voters=[], votes_count=0, uid=123456789
+        text="abc", vote=False, voters=[], votes_count=0, id=123456789
     ) == PollOption._from_graphql(data)
 
 
@@ -23,7 +23,7 @@ def test_poll_option_from_graphql_voted():
         "voters": ["1234", "2345"],
     }
     assert PollOption(
-        text="abc", vote=True, voters=["1234", "2345"], votes_count=2, uid=123456789
+        text="abc", vote=True, voters=["1234", "2345"], votes_count=2, id=123456789
     ) == PollOption._from_graphql(data)
 
 
@@ -39,7 +39,7 @@ def test_poll_option_from_graphql_alternate_format():
         },
     }
     assert PollOption(
-        text="abc", vote=True, voters=["1234", "2345"], votes_count=2, uid=123456789
+        text="abc", vote=True, voters=["1234", "2345"], votes_count=2, id=123456789
     ) == PollOption._from_graphql(data)
 
 
@@ -76,12 +76,12 @@ def test_poll_from_graphql():
     assert Poll(
         title="Some poll",
         options=[
-            PollOption(text="Abc", vote=True, voters=["1234"], votes_count=1, uid=1111),
+            PollOption(text="Abc", vote=True, voters=["1234"], votes_count=1, id=1111),
             PollOption(
-                text="Def", vote=False, voters=["2345", "3456"], votes_count=2, uid=2222
+                text="Def", vote=False, voters=["2345", "3456"], votes_count=2, id=2222
             ),
-            PollOption(text="Ghi", vote=False, voters=[], votes_count=0, uid=3333),
+            PollOption(text="Ghi", vote=False, voters=[], votes_count=0, id=3333),
         ],
         options_count=5,
-        uid=123456789,
+        id=123456789,
     ) == Poll._from_graphql(data)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -10,7 +10,7 @@ def test_search_for(client1):
 
     u = users[0]
 
-    assert u.uid == "4"
+    assert u.id == "4"
     assert u.type == ThreadType.USER
     assert u.photo[:4] == "http"
     assert u.url[:4] == "http"

--- a/tests/test_send.py
+++ b/tests/test_send.py
@@ -13,7 +13,7 @@ def test_send_text(client, catch_event, compare, text):
         mid = client.send(Message(text=text))
 
     assert compare(x, mid=mid, message=text)
-    assert subset(vars(x.res["message_object"]), uid=mid, author=client.uid, text=text)
+    assert subset(vars(x.res["message_object"]), id=mid, author=client.id, text=text)
 
 
 @pytest.mark.parametrize("emoji, emoji_size", EMOJI_LIST)
@@ -24,8 +24,8 @@ def test_send_emoji(client, catch_event, compare, emoji, emoji_size):
     assert compare(x, mid=mid, message=emoji)
     assert subset(
         vars(x.res["message_object"]),
-        uid=mid,
-        author=client.uid,
+        id=mid,
+        author=client.id,
         text=emoji,
         emoji_size=emoji_size,
     )
@@ -38,8 +38,8 @@ def test_send_mentions(client, catch_event, compare, message_with_mentions):
     assert compare(x, mid=mid, message=message_with_mentions.text)
     assert subset(
         vars(x.res["message_object"]),
-        uid=mid,
-        author=client.uid,
+        id=mid,
+        author=client.id,
         text=message_with_mentions.text,
     )
     # The mentions are not ordered by offset
@@ -53,8 +53,8 @@ def test_send_sticker(client, catch_event, compare, sticker):
         mid = client.send(Message(sticker=sticker))
 
     assert compare(x, mid=mid)
-    assert subset(vars(x.res["message_object"]), uid=mid, author=client.uid)
-    assert subset(vars(x.res["message_object"].sticker), uid=sticker.uid)
+    assert subset(vars(x.res["message_object"]), id=mid, author=client.id)
+    assert subset(vars(x.res["message_object"].sticker), id=sticker.id)
 
 
 # Kept for backwards compatibility
@@ -74,7 +74,7 @@ def test_send_images(client, catch_event, compare, method_name, url):
         mid = getattr(client, method_name)(url, Message(text))
 
     assert compare(x, mid=mid, message=text)
-    assert subset(vars(x.res["message_object"]), uid=mid, author=client.uid, text=text)
+    assert subset(vars(x.res["message_object"]), id=mid, author=client.id, text=text)
     assert x.res["message_object"].attachments[0]
 
 
@@ -96,7 +96,7 @@ def test_send_local_files(client, catch_event, compare):
         )
 
     assert compare(x, mid=mid, message=text)
-    assert subset(vars(x.res["message_object"]), uid=mid, author=client.uid, text=text)
+    assert subset(vars(x.res["message_object"]), id=mid, author=client.id, text=text)
     assert len(x.res["message_object"].attachments) == len(files)
 
 
@@ -114,7 +114,7 @@ def test_send_remote_files(client, catch_event, compare):
         )
 
     assert compare(x, mid=mid, message=text)
-    assert subset(vars(x.res["message_object"]), uid=mid, author=client.uid, text=text)
+    assert subset(vars(x.res["message_object"]), id=mid, author=client.id, text=text)
     assert len(x.res["message_object"].attachments) == len(files)
 
 

--- a/tests/test_sticker.py
+++ b/tests/test_sticker.py
@@ -8,12 +8,12 @@ def test_from_graphql_none():
 
 
 def test_from_graphql_minimal():
-    assert Sticker(uid=1) == Sticker._from_graphql({"id": 1})
+    assert Sticker(id=1) == Sticker._from_graphql({"id": 1})
 
 
 def test_from_graphql_normal():
     assert Sticker(
-        uid="369239383222810",
+        id="369239383222810",
         pack="227877430692340",
         is_animated=False,
         frames_per_row=1,
@@ -47,7 +47,7 @@ def test_from_graphql_normal():
 
 def test_from_graphql_animated():
     assert Sticker(
-        uid="144885035685763",
+        id="144885035685763",
         pack="350357561732812",
         is_animated=True,
         medium_sprite_image="https://scontent-arn2-1.xx.fbcdn.net/v/redacted2.png",

--- a/tests/test_thread_interraction.py
+++ b/tests/test_thread_interraction.py
@@ -11,15 +11,15 @@ def test_remove_from_and_add_to_group(client1, client2, group, catch_event):
     # Test both methods, while ensuring that the user gets added to the group
     try:
         with catch_event("on_person_removed") as x:
-            client1.remove_user_from_group(client2.uid, group["id"])
+            client1.remove_user_from_group(client2.id, group["id"])
         assert subset(
-            x.res, removed_id=client2.uid, author_id=client1.uid, thread_id=group["id"]
+            x.res, removed_id=client2.id, author_id=client1.id, thread_id=group["id"]
         )
     finally:
         with catch_event("on_people_added") as x:
-            client1.add_users_to_group(client2.uid, group["id"])
+            client1.add_users_to_group(client2.id, group["id"])
         assert subset(
-            x.res, added_ids=[client2.uid], author_id=client1.uid, thread_id=group["id"]
+            x.res, added_ids=[client2.id], author_id=client1.id, thread_id=group["id"]
         )
 
 
@@ -27,15 +27,15 @@ def test_remove_from_and_add_admins_to_group(client1, client2, group, catch_even
     # Test both methods, while ensuring that the user gets added as group admin
     try:
         with catch_event("on_admin_removed") as x:
-            client1.remove_group_admins(client2.uid, group["id"])
+            client1.remove_group_admins(client2.id, group["id"])
         assert subset(
-            x.res, removed_id=client2.uid, author_id=client1.uid, thread_id=group["id"]
+            x.res, removed_id=client2.id, author_id=client1.id, thread_id=group["id"]
         )
     finally:
         with catch_event("on_admin_added") as x:
-            client1.add_group_admins(client2.uid, group["id"])
+            client1.add_group_admins(client2.id, group["id"])
         assert subset(
-            x.res, added_id=client2.uid, author_id=client1.uid, thread_id=group["id"]
+            x.res, added_id=client2.id, author_id=client1.id, thread_id=group["id"]
         )
 
 
@@ -45,7 +45,7 @@ def test_change_title(client1, group, catch_event):
         client1.change_thread_title(title, group["id"], thread_type=ThreadType.GROUP)
     assert subset(
         x.res,
-        author_id=client1.uid,
+        author_id=client1.id,
         new_title=title,
         thread_id=group["id"],
         thread_type=ThreadType.GROUP,
@@ -55,8 +55,8 @@ def test_change_title(client1, group, catch_event):
 def test_change_nickname(client, client_all, catch_event, compare):
     nickname = random_hex()
     with catch_event("on_nickname_change") as x:
-        client.change_nickname(nickname, client_all.uid)
-    assert compare(x, changed_for=client_all.uid, new_nickname=nickname)
+        client.change_nickname(nickname, client_all.id)
+    assert compare(x, changed_for=client_all.id, new_nickname=nickname)
 
 
 @pytest.mark.parametrize(
@@ -83,7 +83,7 @@ def test_change_image_local(client1, group, catch_event):
     with catch_event("on_image_change") as x:
         image_id = client1.change_group_image_local(url, group["id"])
     assert subset(
-        x.res, new_image=image_id, author_id=client1.uid, thread_id=group["id"]
+        x.res, new_image=image_id, author_id=client1.id, thread_id=group["id"]
     )
 
 
@@ -93,7 +93,7 @@ def test_change_image_remote(client1, group, catch_event):
     with catch_event("on_image_change") as x:
         image_id = client1.change_group_image_remote(url, group["id"])
     assert subset(
-        x.res, new_image=image_id, author_id=client1.uid, thread_id=group["id"]
+        x.res, new_image=image_id, author_id=client1.id, thread_id=group["id"]
     )
 
 
@@ -130,7 +130,7 @@ def test_change_approval_mode(client1, group, catch_event, require_admin_approva
     assert subset(
         x.res,
         approval_mode=require_admin_approval,
-        author_id=client1.uid,
+        author_id=client1.id,
         thread_id=group["id"],
     )
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -17,7 +17,7 @@ def test_user_from_graphql():
         "viewer_affinity": 0.4560002,
     }
     assert User(
-        uid="1234",
+        id="1234",
         photo=fbchat.Image(url="https://scontent-arn2-1.xx.fbcdn.net/v/..."),
         name="Abc Def Ghi",
         url="https://www.facebook.com/profile.php?id=1234",
@@ -137,7 +137,7 @@ def test_user_from_thread_fetch():
         "delivery_receipts": ...,
     }
     assert User(
-        uid="1234",
+        id="1234",
         photo=fbchat.Image(url="https://scontent-arn2-1.xx.fbcdn.net/v/..."),
         name="Abc Def Ghi",
         last_active=datetime.datetime(2017, 7, 14, 2, 40, tzinfo=datetime.timezone.utc),
@@ -175,7 +175,7 @@ def test_user_from_all_fetch():
         "is_blocked": False,
     }
     assert User(
-        uid="1234",
+        id="1234",
         photo=fbchat.Image(url="https://scontent-arn2-1.xx.fbcdn.net/v/..."),
         name="Abc Def Ghi",
         url="https://www.facebook.com/profile.php?id=1234",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,12 +22,12 @@ EMOJI_LIST = [
 ]
 
 STICKER_LIST = [
-    Sticker(uid="767334476626295"),
+    Sticker(id="767334476626295"),
     pytest.param(
-        Sticker(uid="0"), marks=[pytest.mark.xfail(raises=FBchatFacebookError)]
+        Sticker(id="0"), marks=[pytest.mark.xfail(raises=FBchatFacebookError)]
     ),
     pytest.param(
-        Sticker(uid=None), marks=[pytest.mark.xfail(raises=FBchatFacebookError)]
+        Sticker(id=None), marks=[pytest.mark.xfail(raises=FBchatFacebookError)]
     ),
 ]
 


### PR DESCRIPTION
Rename `.uid` to `.id` on all relevant classes.

Removes it from `Client`, in favor of `Client.session.user_id`.