### PR TITLE
Refactor limits

### DIFF
--- a/examples/fetch.py
+++ b/examples/fetch.py
@@ -1,4 +1,3 @@
-import itertools
 import fbchat
 
 session = fbchat.Session.login("<email>", "<password>")
@@ -62,7 +61,9 @@ print("thread's name: {}".format(thread.name))
 # Here should be an example of `getUnread`
 
 
-# Print image url for 20 last images from thread.
-images = thread.fetch_images()
-for image in itertools.islice(image, 20):
-    print(image.large_preview_url)
+# Print image url for up to 20 last images from thread.
+images = list(thread.fetch_images(limit=20))
+for image in images:
+    if isinstance(image, fbchat.ImageAttachment):
+        url = c.fetch_image_url(image.id)
+        print(url)

--- a/fbchat/_file.py
+++ b/fbchat/_file.py
@@ -91,8 +91,6 @@ class ImageAttachment(Attachment):
 
     @classmethod
     def _from_list(cls, data):
-        data = data["node"]
-
         previews = {
             Image._from_uri_or_none(data["image"]),
             Image._from_uri(data["image1"]),
@@ -156,7 +154,6 @@ class VideoAttachment(Attachment):
 
     @classmethod
     def _from_list(cls, data):
-        data = data["node"]
         previews = {
             Image._from_uri(data["image"]),
             Image._from_uri(data["image1"]),

--- a/fbchat/_message.py
+++ b/fbchat/_message.py
@@ -171,6 +171,34 @@ class Message:
 
 
 @attrs_default
+class MessageSnippet(Message):
+    """Represents data in a Facebook message snippet.
+
+    Inherits `Message`.
+    """
+
+    #: ID of the sender
+    author = attr.ib()
+    #: Datetime of when the message was sent
+    created_at = attr.ib()
+    #: The actual message
+    text = attr.ib()
+    #: A dict with offsets, mapped to the matched text
+    matched_keywords = attr.ib()
+
+    @classmethod
+    def _parse(cls, thread, data):
+        return cls(
+            thread=thread,
+            id=data["message_id"],
+            author=data["author"].rstrip("fbid:"),
+            created_at=_util.millis_to_datetime(data["timestamp"]),
+            text=data["body"],
+            matched_keywords={int(k): v for k, v in data["matched_keywords"].items()},
+        )
+
+
+@attrs_default
 class MessageData(Message):
     """Represents data in a Facebook message.
 

--- a/fbchat/_util.py
+++ b/fbchat/_util.py
@@ -13,6 +13,8 @@ from ._exception import (
     FBchatPleaseRefresh,
 )
 
+from typing import Iterable, Optional
+
 #: Default list of user agents
 USER_AGENTS = [
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.90 Safari/537.36",
@@ -22,6 +24,24 @@ USER_AGENTS = [
     "Mozilla/5.0 (X11; CrOS i686 2268.111.0) AppleWebKit/536.11 (KHTML, like Gecko) Chrome/20.0.1132.57 Safari/536.11",
     "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/536.6 (KHTML, like Gecko) Chrome/20.0.1092.0 Safari/536.6",
 ]
+
+
+def get_limits(limit: Optional[int], max_limit: int) -> Iterable[int]:
+    """Helper that generates limits based on a max limit."""
+    if limit is None:
+        # Generate infinite items
+        while True:
+            yield max_limit
+
+    if limit < 0:
+        raise ValueError("Limit cannot be negative")
+
+    # Generate n items
+    yield from [max_limit] * (limit // max_limit)
+
+    remainder = limit % max_limit
+    if remainder:
+        yield remainder
 
 
 def now():

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -46,7 +46,7 @@ def test_imageattachment_from_list():
                 height=988,
             ),
         },
-    ) == ImageAttachment._from_list({"node": data})
+    ) == ImageAttachment._from_list(data)
 
 
 def test_videoattachment_from_list():
@@ -88,7 +88,7 @@ def test_videoattachment_from_list():
                 height=368,
             ),
         },
-    ) == VideoAttachment._from_list({"node": data})
+    ) == VideoAttachment._from_list(data)
 
 
 def test_graphql_to_attachment_empty():


### PR DESCRIPTION
Make the following methods return an iterable, so that we can batch requests where necessary
- [x] ThreadABC.search_messages
- [x] ThreadABC.fetch_messages
- [x] ThreadABC.fetch_images
- [x] Client.search_for_users
- [x] Client.search_for_pages
- [x] Client.search_for_groups
- [x] Client.search_for_threads
- [x] Client.search_messages
- [x] Client.fetch_threads

Fixes #503 